### PR TITLE
Release 0.2.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Purecipes are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.2.1] - 2026-05-25
+
+### Fixed
+
+- Google Sign-In on distributed Android builds. Release 0.2.0 was built without the Google Web Client ID in CI, which blocked sign-in; CI now supplies that configuration so Google sign-in works again.
+- Account screen: general error messages appear at the top so they are easier to notice.
+
 ## [0.2.0] - 2026-05-24
 
 ### Added

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 
 #common configuration
 
-versionCode = "2"
-versionName = "0.2.0"
+versionCode = "3"
+versionName = "0.2.1"
 minSdkVersion = "24"
 compileSdkVersion = "37"
 targetSdkVersion = "37"


### PR DESCRIPTION
## Summary

Android release **0.2.1** (since `v0.2.0`).

Bugfix release addressing Google Sign-In on Firebase-distributed builds and account error message placement.

## Review before merge

- [ ] Edit CHANGELOG.md for accuracy and tester-friendly wording
- [ ] Confirm `versionCode` (3) and `versionName` (0.2.1) in `gradle/libs.versions.toml`
- [ ] Confirm `PURECIPES_GOOGLE_WEB_CLIENT_ID` is set in GitHub repository secrets (no code PR; required for the Google Sign-In fix in distributed builds)
- [ ] Merge, then tag `v0.2.1` on `main` to trigger distribution

Do not tag until this PR is merged.