### PR TITLE
Pass Google web client ID into Android distribute CI

### DIFF
--- a/.github/workflows/distribute-android.yml
+++ b/.github/workflows/distribute-android.yml
@@ -67,8 +67,18 @@ jobs:
           echo "${FIREBASE_SERVICE_ACCOUNT_JSON}" > "${CREDS_PATH}"
           echo "GOOGLE_APPLICATION_CREDENTIALS=${CREDS_PATH}" >> "${GITHUB_ENV}"
 
+      - name: Require Google web client ID for release build
+        env:
+          PURECIPES_GOOGLE_WEB_CLIENT_ID: ${{ secrets.PURECIPES_GOOGLE_WEB_CLIENT_ID }}
+        run: |
+          if [[ -z "${PURECIPES_GOOGLE_WEB_CLIENT_ID}" ]]; then
+            echo "::error::PURECIPES_GOOGLE_WEB_CLIENT_ID repository secret is required for release builds (Google Sign-In)." >&2
+            exit 1
+          fi
+
       - name: Build and distribute release APK
         env:
+          PURECIPES_GOOGLE_WEB_CLIENT_ID: ${{ secrets.PURECIPES_GOOGLE_WEB_CLIENT_ID }}
           PURECIPES_SIGNING_STORE_PASSWORD: ${{ secrets.PURECIPES_SIGNING_STORE_PASSWORD }}
           PURECIPES_SIGNING_KEY_ALIAS: ${{ secrets.PURECIPES_SIGNING_KEY_ALIAS }}
           PURECIPES_SIGNING_KEY_PASSWORD: ${{ secrets.PURECIPES_SIGNING_KEY_PASSWORD }}

--- a/docs/releases/android-app-distribution.md
+++ b/docs/releases/android-app-distribution.md
@@ -23,6 +23,7 @@ Prepare releases locally with the GitHub MCP server: [`.agents/instructions/andr
 | `PURECIPES_SIGNING_STORE_PASSWORD` | Keystore password |
 | `PURECIPES_SIGNING_KEY_ALIAS` | Key alias |
 | `PURECIPES_SIGNING_KEY_PASSWORD` | Key password |
+| `PURECIPES_GOOGLE_WEB_CLIENT_ID` | Google Sign-In web client ID (Gradle `BuildConfig`; same value as `client_type` 3 in `google-services.json`, not a secret but stored here for CI) |
 | `FIREBASE_SERVICE_ACCOUNT_JSON` | App Distribution upload |
 | `GRADLE_ENCRYPTION_KEY` | Optional Gradle build scan cache |
 


### PR DESCRIPTION
## Summary

Maps `PURECIPES_GOOGLE_WEB_CLIENT_ID` from GitHub repository secrets into the **Distribute Android** workflow so release APKs get a non-empty `BuildConfig.PURECIPES_GOOGLE_WEB_CLIENT_ID` (required for Google Sign-In on Firebase-distributed builds).

Adds a fail-fast step when the secret is missing.

Documents the secret in [docs/releases/android-app-distribution.md](docs/releases/android-app-distribution.md).
