### PR TITLE
Release 0.2.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Purecipes are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.2.2] - 2026-05-25
+
+### Fixed
+
+- Google Sign-In on distributed Android builds: release builds from CI now receive the Google Web Client ID required for sign-in.
+
 ## [0.2.1] - 2026-05-25
 
 ### Fixed

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 
 #common configuration
 
-versionCode = "3"
-versionName = "0.2.1"
+versionCode = "4"
+versionName = "0.2.2"
 minSdkVersion = "24"
 compileSdkVersion = "37"
 targetSdkVersion = "37"


### PR DESCRIPTION
## Summary

- Adds `## [0.2.2]` to `CHANGELOG.md` with the CI distribute fix for Google Sign-In on release APKs.
- Bumps `versionName` to `0.2.2` and `versionCode` to `4` in `gradle/libs.versions.toml`.

**Previous tag:** `v0.2.1`  
**New version:** `0.2.2`

## Test plan

- [x] Changelog wording is accurate and tester-friendly
- [x] Confirm `versionCode` and `versionName` in `gradle/libs.versions.toml`
- [x] Merge to `main`, then tag `v0.2.2` to trigger Android distribution