### PR TITLE
Fix #129 Navigation: promote ad-hoc nav arguments onto destinations or SavedStateHandle

### DIFF
--- a/feature/auth/ui/src/commonMain/kotlin/app/purecipes/feature/auth/ui/navigation/AuthNavigation.kt
+++ b/feature/auth/ui/src/commonMain/kotlin/app/purecipes/feature/auth/ui/navigation/AuthNavigation.kt
@@ -12,13 +12,13 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
 
-inline fun EntryProviderScope<NavKey>.installAuthFlow(
+fun EntryProviderScope<NavKey>.installAuthFlow(
 	navigator: Navigator,
 	googleWebClientId: String?,
-	noinline onOpenSettings: () -> Unit,
-	noinline onNavigateToEmailRegistration: () -> Unit,
-	noinline onNavigateToSignIn: () -> Unit,
-	noinline onRegistrationSuccess: (String) -> Unit,
+	onOpenSettings: () -> Unit,
+	onNavigateToEmailRegistration: () -> Unit,
+	onNavigateToSignIn: () -> Unit,
+	onRegistrationSuccess: (String) -> Unit,
 ) {
 	entry<AccountDestination> {
 		AuthenticationScreen(

--- a/feature/cooking/ui/src/commonMain/kotlin/app/purecipes/feature/cooking/ui/navigation/CookingNavigation.kt
+++ b/feature/cooking/ui/src/commonMain/kotlin/app/purecipes/feature/cooking/ui/navigation/CookingNavigation.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
 
-inline fun EntryProviderScope<NavKey>.installCookingFlow(
+fun EntryProviderScope<NavKey>.installCookingFlow(
 	navigator: Navigator,
 ) {
 	entry<RecipeCookingDestination> { destination ->

--- a/feature/favorites/ui/src/commonMain/kotlin/app/purecipes/feature/favorites/ui/navigation/FavoritesDestination.kt
+++ b/feature/favorites/ui/src/commonMain/kotlin/app/purecipes/feature/favorites/ui/navigation/FavoritesDestination.kt
@@ -4,4 +4,6 @@ import androidx.navigation3.runtime.NavKey
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object FavoritesDestination : NavKey
+data class FavoritesDestination(
+	val cookbookShareToken: String? = null,
+) : NavKey

--- a/feature/favorites/ui/src/commonMain/kotlin/app/purecipes/feature/favorites/ui/navigation/FavoritesNavigation.kt
+++ b/feature/favorites/ui/src/commonMain/kotlin/app/purecipes/feature/favorites/ui/navigation/FavoritesNavigation.kt
@@ -9,10 +9,10 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
 
-inline fun EntryProviderScope<NavKey>.installFavoritesFlow(
+fun EntryProviderScope<NavKey>.installFavoritesFlow(
 	refreshSignal: Int,
 	sessionKey: String?,
-	noinline onRecipeSelect: (Int) -> Unit,
+	onRecipeSelect: (Int) -> Unit,
 ) {
 	entry<FavoritesDestination> { destination ->
 		FavoritesScreen(

--- a/feature/favorites/ui/src/commonMain/kotlin/app/purecipes/feature/favorites/ui/navigation/FavoritesNavigation.kt
+++ b/feature/favorites/ui/src/commonMain/kotlin/app/purecipes/feature/favorites/ui/navigation/FavoritesNavigation.kt
@@ -12,15 +12,14 @@ import kotlinx.serialization.modules.subclass
 inline fun EntryProviderScope<NavKey>.installFavoritesFlow(
 	refreshSignal: Int,
 	sessionKey: String?,
-	initialCookbookShareToken: String?,
 	noinline onRecipeSelect: (Int) -> Unit,
 ) {
-	entry<FavoritesDestination> {
+	entry<FavoritesDestination> { destination ->
 		FavoritesScreen(
 			refreshSignal = refreshSignal,
 			modifier = Modifier.fillMaxSize(),
 			sessionKey = sessionKey,
-			initialCookbookShareToken = initialCookbookShareToken,
+			initialCookbookShareToken = destination.cookbookShareToken,
 			onRecipeSelect = onRecipeSelect,
 		)
 	}

--- a/feature/main/src/commonMain/kotlin/app/purecipes/feature/main/ui/MainScreen.kt
+++ b/feature/main/src/commonMain/kotlin/app/purecipes/feature/main/ui/MainScreen.kt
@@ -111,9 +111,6 @@ private fun MainScreenContent(
 						installSearchFlow(
 							isSignedIn = authenticationState is AuthenticationState.SignedIn,
 							sessionKey = sessionKey,
-							initialShowFilterSheet = remember(sessionKey) {
-								viewModel.takePendingOpenSearchFilters()
-							},
 							onRecipeSelect = viewModel::onRecipeSelected,
 							onRequestLogInForFilters = {
 								viewModel.requestLoginForPostLoginAction(
@@ -135,9 +132,6 @@ private fun MainScreenContent(
 						installFavoritesFlow(
 							refreshSignal = favoritesRefreshSignal,
 							sessionKey = sessionKey,
-							initialCookbookShareToken = remember {
-								viewModel.takePendingCookbookShareToken()
-							},
 							onRecipeSelect = viewModel::onRecipeSelected,
 						)
 						installCreateFlow(

--- a/feature/main/src/commonMain/kotlin/app/purecipes/feature/main/ui/MainTab.kt
+++ b/feature/main/src/commonMain/kotlin/app/purecipes/feature/main/ui/MainTab.kt
@@ -19,11 +19,11 @@ internal data class MainTab(
 
 internal val mainTabs = listOf(
 	MainTab(
-		destination = SearchDestination,
+		destination = SearchDestination(),
 		label = "Search",
 	),
 	MainTab(
-		destination = FavoritesDestination,
+		destination = FavoritesDestination(),
 		label = "Favorites",
 	),
 	MainTab(
@@ -36,12 +36,16 @@ internal val mainTabs = listOf(
 	),
 )
 
-internal fun MainTab.isSelected(rootDestination: NavKey?): Boolean = rootDestination == destination
+internal fun MainTab.isSelected(rootDestination: NavKey?): Boolean = when (destination) {
+	is SearchDestination -> rootDestination is SearchDestination
+	is FavoritesDestination -> rootDestination is FavoritesDestination
+	else -> rootDestination == destination
+}
 
 internal val MainTab.icon: ImageVector
 	get() = when (destination) {
-		SearchDestination -> Icons.Filled.Search
-		FavoritesDestination -> Icons.Filled.Favorite
+		is SearchDestination -> Icons.Filled.Search
+		is FavoritesDestination -> Icons.Filled.Favorite
 		CreateDestination -> Icons.Filled.Add
 		AccountDestination -> Icons.Filled.Person
 		else -> error("$destination is not a tab destination")

--- a/feature/main/src/commonMain/kotlin/app/purecipes/feature/main/ui/MainViewModel.kt
+++ b/feature/main/src/commonMain/kotlin/app/purecipes/feature/main/ui/MainViewModel.kt
@@ -56,11 +56,10 @@ class MainViewModel(
 	private val ownsCoroutineScope = coroutineScope == null
 	private val scope = coroutineScope ?: CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
-	private var backStack: NavBackStack<NavKey> = NavBackStack(SearchDestination)
+	private var backStack: NavBackStack<NavKey> = NavBackStack(SearchDestination())
 
 	private var pendingPostLoginOrigin: PostLoginNavOrigin? = null
-	private var pendingOpenSearchFiltersAfterLogin: Boolean = false
-	private var pendingCookbookShareToken: String? = null
+	private var stagedCookbookShareToken: String? = null
 
 	private var previousAuthenticationState: AuthenticationState? = null
 	private var previousSessionKey: String? = null
@@ -98,7 +97,7 @@ class MainViewModel(
 				backStack.removeAt(backStack.lastIndex)
 				return true
 			}
-			return backStack.firstOrNull() != SearchDestination
+			return backStack.firstOrNull() !is SearchDestination
 		}
 	}
 
@@ -126,7 +125,7 @@ class MainViewModel(
 
 	fun clearPostLoginNavigationState() {
 		pendingPostLoginOrigin = null
-		pendingOpenSearchFiltersAfterLogin = false
+		stagedCookbookShareToken = null
 	}
 
 	internal fun requestLoginForPostLoginAction(origin: PostLoginNavOrigin) {
@@ -142,7 +141,7 @@ class MainViewModel(
 					serializersModule = mainNavigationSerializersModule()
 				}
 			},
-			SearchDestination,
+			SearchDestination(),
 		)
 		backStack = stack
 		return stack
@@ -154,29 +153,17 @@ class MainViewModel(
 		return origin
 	}
 
-	internal fun markPendingOpenSearchFiltersAfterLogin() {
-		pendingOpenSearchFiltersAfterLogin = true
-	}
-
-	internal fun takePendingOpenSearchFilters(): Boolean {
-		if (!pendingOpenSearchFiltersAfterLogin) return false
-		pendingOpenSearchFiltersAfterLogin = false
-		return true
-	}
-
-	fun shouldExit(): Boolean = backStack.size == 1 && backStack.firstOrNull() == SearchDestination
+	fun shouldExit(): Boolean = backStack.size == 1 && backStack.firstOrNull() is SearchDestination
 
 	internal fun peekBackStack(): List<NavKey> = backStack.toList()
 
 	internal fun onTabSelected(tab: MainTab) {
 		if (tab.destination !is AccountDestination) {
 			pendingPostLoginOrigin = null
-			if (tab.destination != SearchDestination) {
-				pendingOpenSearchFiltersAfterLogin = false
-			}
 		}
-		if (backStack.size != 1 || backStack.firstOrNull() != tab.destination) {
-			navigator.replaceTabRoot(tab.destination)
+		val root = tabRootDestination(tab)
+		if (backStack.size != 1 || !backStack.firstOrNull().isSameTabRoot(root)) {
+			navigator.replaceTabRoot(root)
 		}
 	}
 
@@ -192,20 +179,14 @@ class MainViewModel(
 	}
 
 	fun stageCookbookShareImport(token: String) {
-		pendingCookbookShareToken = token
-	}
-
-	internal fun takePendingCookbookShareToken(): String? {
-		val token = pendingCookbookShareToken
-		pendingCookbookShareToken = null
-		return token
+		stagedCookbookShareToken = token
 	}
 
 	private fun navigateToRecipe(recipeId: Int) {
-		pendingCookbookShareToken = null
-		if (backStack.firstOrNull() != SearchDestination) {
+		stagedCookbookShareToken = null
+		if (backStack.firstOrNull() !is SearchDestination) {
 			backStack.clear()
-			backStack += SearchDestination
+			backStack += SearchDestination()
 		}
 		while (
 			backStack.lastOrNull() is RecipeDetailsDestination ||
@@ -217,8 +198,8 @@ class MainViewModel(
 	}
 
 	private fun navigateToCookbookShare(token: String) {
-		stageCookbookShareImport(token)
-		onTabSelected(mainTabs.first { it.destination == FavoritesDestination })
+		stagedCookbookShareToken = null
+		navigator.replaceTabRoot(FavoritesDestination(cookbookShareToken = token))
 	}
 
 	fun onStartCooking(recipeId: Int) {
@@ -286,13 +267,11 @@ class MainViewModel(
 		} else if (previous is AuthenticationState.SignedOut && state is AuthenticationState.SignedIn) {
 			onAuthenticationSucceeded()
 			when (takePostLoginOriginAfterSignIn()) {
-				PostLoginNavOrigin.RECIPE_SEARCH_FILTERS -> {
-					markPendingOpenSearchFiltersAfterLogin()
-					onTabSelected(mainTabs.first { it.destination == SearchDestination })
-				}
+				PostLoginNavOrigin.RECIPE_SEARCH_FILTERS ->
+					navigator.replaceTabRoot(SearchDestination(openFiltersOnStart = true))
 
 				PostLoginNavOrigin.COOKBOOK_SHARE_IMPORT ->
-					onTabSelected(mainTabs.first { it.destination == FavoritesDestination })
+					onTabSelected(mainTabs.first { it.destination is FavoritesDestination })
 
 				null -> Unit
 			}
@@ -322,6 +301,24 @@ class MainViewModel(
 				}
 			}
 		}
+	}
+
+	private fun tabRootDestination(tab: MainTab): NavKey = when (tab.destination) {
+		is SearchDestination -> SearchDestination()
+		is FavoritesDestination -> FavoritesDestination(cookbookShareToken = consumeStagedCookbookShareToken())
+		else -> tab.destination
+	}
+
+	private fun consumeStagedCookbookShareToken(): String? {
+		val token = stagedCookbookShareToken
+		stagedCookbookShareToken = null
+		return token
+	}
+
+	private fun NavKey?.isSameTabRoot(root: NavKey): Boolean = when (root) {
+		is SearchDestination -> this is SearchDestination
+		is FavoritesDestination -> this is FavoritesDestination
+		else -> this == root
 	}
 
 	private fun NavKey?.isAccountAuthFlowDestination(): Boolean {

--- a/feature/main/src/commonTest/kotlin/app/purecipes/feature/main/ui/MainViewModelStartTest.kt
+++ b/feature/main/src/commonTest/kotlin/app/purecipes/feature/main/ui/MainViewModelStartTest.kt
@@ -4,6 +4,7 @@ import app.purecipes.feature.auth.domain.model.AuthProvider
 import app.purecipes.feature.auth.domain.model.AuthenticationState
 import app.purecipes.feature.auth.domain.model.GoogleAuthenticationProfile
 import app.purecipes.feature.auth.ui.navigation.AccountDestination
+import app.purecipes.feature.favorites.ui.navigation.FavoritesDestination
 import app.purecipes.feature.recipedetails.ui.navigation.RecipeDetailsDestination
 import app.purecipes.feature.search.ui.navigation.SearchDestination
 import app.purecipes.feature.sharing.domain.model.PurecipesLink
@@ -51,14 +52,15 @@ class MainViewModelStartTest {
 		)
 
 		viewModel.authenticationState shouldBe AuthenticationState.SignedIn(sampleUser)
-		viewModel.peekBackStack() shouldBe listOf(SearchDestination)
-		viewModel.takePendingOpenSearchFilters() shouldBe true
+		viewModel.peekBackStack() shouldBe listOf(SearchDestination(openFiltersOnStart = true))
 	}
 
 	@Test
-	fun `start routes unsigned cookbook share to account login`() = runTest {
+	fun `start routes unsigned cookbook share to account login then favorites with token`() = runTest {
 		val links = MutableSharedFlow<PurecipesLink>(extraBufferCapacity = 1)
+		val authenticationRepository = FakeAuthenticationRepository()
 		val viewModel = mainViewModelForTest(
+			authenticationRepository = authenticationRepository,
 			incomingLinkRepository = incomingLinksRepository(links),
 			coroutineScope = testViewModelScope(),
 		)
@@ -66,8 +68,18 @@ class MainViewModelStartTest {
 		links.emit(PurecipesLink.CookbookShare(sampleShareToken))
 
 		viewModel.peekBackStack() shouldBe listOf(AccountDestination)
-		viewModel.takePostLoginOriginAfterSignIn() shouldBe PostLoginNavOrigin.COOKBOOK_SHARE_IMPORT
-		viewModel.takePendingCookbookShareToken() shouldBe sampleShareToken
+		authenticationRepository.signInWithGoogle(
+			GoogleAuthenticationProfile(
+				idToken = sampleUser.id,
+				email = sampleUser.email,
+				displayName = sampleUser.displayName,
+				profileImageUrl = sampleUser.profileImageUrl,
+			),
+		)
+
+		viewModel.peekBackStack() shouldBe listOf(
+			FavoritesDestination(cookbookShareToken = sampleShareToken),
+		)
 	}
 
 	@Test
@@ -81,7 +93,7 @@ class MainViewModelStartTest {
 		viewModel.start()
 		links.emit(PurecipesLink.Recipe(77))
 
-		viewModel.peekBackStack() shouldBe listOf(SearchDestination, RecipeDetailsDestination(77))
+		viewModel.peekBackStack() shouldBe listOf(SearchDestination(), RecipeDetailsDestination(77))
 	}
 
 	@Test
@@ -144,11 +156,10 @@ class MainViewModelStartTest {
 				profileImageUrl = sampleUser.profileImageUrl,
 			),
 		)
-		viewModel.takePendingOpenSearchFilters() shouldBe true
+		viewModel.peekBackStack() shouldBe listOf(SearchDestination(openFiltersOnStart = true))
 
 		authenticationRepository.signOut()
 
-		viewModel.takePendingOpenSearchFilters() shouldBe false
 		viewModel.takePostLoginOriginAfterSignIn() shouldBe null
 	}
 }

--- a/feature/main/src/commonTest/kotlin/app/purecipes/feature/main/ui/MainViewModelTest.kt
+++ b/feature/main/src/commonTest/kotlin/app/purecipes/feature/main/ui/MainViewModelTest.kt
@@ -32,41 +32,23 @@ class MainViewModelTest {
 	}
 
 	@Test
-	fun `post login resume opens search tab and enables open filters`() {
-		val viewModel = mainViewModelForTest()
-		viewModel.requestLoginForPostLoginAction(PostLoginNavOrigin.RECIPE_SEARCH_FILTERS)
-
-		viewModel.onOpenEmailSignIn(prefilledEmail = "taylor@example.com")
-		viewModel.onAuthenticationSucceeded()
-
-		viewModel.takePostLoginOriginAfterSignIn() shouldBe PostLoginNavOrigin.RECIPE_SEARCH_FILTERS
-		viewModel.markPendingOpenSearchFiltersAfterLogin()
-
-		viewModel.onTabSelected(mainTabs.first { it.destination == SearchDestination })
-		viewModel.takePendingOpenSearchFilters() shouldBe true
-		viewModel.peekBackStack() shouldBe listOf<NavKey>(SearchDestination)
-	}
-
-	@Test
-	fun `selecting search tab clears pending post login origin without consuming open filters flag`() {
+	fun `selecting search tab clears pending post login origin and resets open filters destination`() {
 		val viewModel = mainViewModelForTest()
 
-		viewModel.onTabSelected(mainTabs.first { it.destination == AccountDestination })
-		viewModel.markPendingOpenSearchFiltersAfterLogin()
-		viewModel.onTabSelected(mainTabs.first { it.destination == SearchDestination })
+		viewModel.onTabSelected(mainTabs.first { it.destination is AccountDestination })
+		viewModel.onTabSelected(mainTabs.first { it.destination is SearchDestination })
 
-		viewModel.peekBackStack() shouldBe listOf<NavKey>(SearchDestination)
+		viewModel.peekBackStack() shouldBe listOf<NavKey>(SearchDestination())
 		viewModel.takePostLoginOriginAfterSignIn() shouldBe null
-		viewModel.takePendingOpenSearchFilters() shouldBe true
 	}
 
 	@Test
 	fun `tab selection resets stack to selected destination`() {
 		val viewModel = mainViewModelForTest()
 		viewModel.onRecipeSelected(42)
-		viewModel.onTabSelected(mainTabs.first { it.destination == FavoritesDestination })
+		viewModel.onTabSelected(mainTabs.first { it.destination is FavoritesDestination })
 
-		viewModel.peekBackStack() shouldBe listOf<NavKey>(FavoritesDestination)
+		viewModel.peekBackStack() shouldBe listOf<NavKey>(FavoritesDestination())
 	}
 
 	@Test
@@ -91,28 +73,33 @@ class MainViewModelTest {
 	@Test
 	fun `deep link to recipe opens recipe details on search tab`() {
 		val viewModel = mainViewModelForTest()
-		viewModel.onTabSelected(mainTabs.first { it.destination == FavoritesDestination })
+		viewModel.onTabSelected(mainTabs.first { it.destination is FavoritesDestination })
 		viewModel.onDeepLink(PurecipesLink.Recipe(99))
 
-		viewModel.peekBackStack() shouldBe listOf<NavKey>(SearchDestination, RecipeDetailsDestination(99))
+		viewModel.peekBackStack() shouldBe listOf<NavKey>(SearchDestination(), RecipeDetailsDestination(99))
 	}
 
 	@Test
-	fun `deep link to cookbook share switches to favorites and stores pending share token`() {
+	fun `deep link to cookbook share switches to favorites with share token on destination`() {
 		val viewModel = mainViewModelForTest()
 		viewModel.onDeepLink(PurecipesLink.CookbookShare(sampleShareToken))
 
-		viewModel.peekBackStack() shouldBe listOf<NavKey>(FavoritesDestination)
-		viewModel.takePendingCookbookShareToken() shouldBe sampleShareToken
+		viewModel.peekBackStack() shouldBe listOf<NavKey>(
+			FavoritesDestination(cookbookShareToken = sampleShareToken),
+		)
 	}
 
 	@Test
-	fun `stage cookbook share import stores token without changing tabs`() {
+	fun `stage cookbook share import stores token until favorites tab is selected`() {
 		val viewModel = mainViewModelForTest()
 		viewModel.stageCookbookShareImport(sampleShareToken)
 
-		viewModel.peekBackStack() shouldBe listOf<NavKey>(SearchDestination)
-		viewModel.takePendingCookbookShareToken() shouldBe sampleShareToken
+		viewModel.peekBackStack() shouldBe listOf<NavKey>(SearchDestination())
+		viewModel.onTabSelected(mainTabs.first { it.destination is FavoritesDestination })
+
+		viewModel.peekBackStack() shouldBe listOf<NavKey>(
+			FavoritesDestination(cookbookShareToken = sampleShareToken),
+		)
 	}
 
 	@Test
@@ -122,6 +109,6 @@ class MainViewModelTest {
 		viewModel.onStartCooking(42)
 		viewModel.onBack()
 
-		viewModel.peekBackStack() shouldBe listOf<NavKey>(SearchDestination, RecipeDetailsDestination(42))
+		viewModel.peekBackStack() shouldBe listOf<NavKey>(SearchDestination(), RecipeDetailsDestination(42))
 	}
 }

--- a/feature/main/src/commonTest/kotlin/app/purecipes/feature/main/ui/MainViewModelTest.kt
+++ b/feature/main/src/commonTest/kotlin/app/purecipes/feature/main/ui/MainViewModelTest.kt
@@ -36,7 +36,7 @@ class MainViewModelTest {
 		val viewModel = mainViewModelForTest()
 
 		viewModel.onTabSelected(mainTabs.first { it.destination == AccountDestination })
-		viewModel.onTabSelected(mainTabs.first { it.destination == SearchDestination })
+		viewModel.onTabSelected(mainTabs.first { it.destination is SearchDestination })
 
 		viewModel.peekBackStack() shouldBe listOf<NavKey>(SearchDestination())
 		viewModel.takePostLoginOriginAfterSignIn() shouldBe null
@@ -46,7 +46,7 @@ class MainViewModelTest {
 	fun `tab selection resets stack to selected destination`() {
 		val viewModel = mainViewModelForTest()
 		viewModel.onRecipeSelected(42)
-		viewModel.onTabSelected(mainTabs.first { it.destination == FavoritesDestination })
+		viewModel.onTabSelected(mainTabs.first { it.destination is FavoritesDestination })
 
 		viewModel.peekBackStack() shouldBe listOf<NavKey>(FavoritesDestination())
 	}
@@ -67,16 +67,16 @@ class MainViewModelTest {
 		viewModel.onOpenSettings()
 		viewModel.onAuthenticationSucceeded()
 
-		viewModel.peekBackStack() shouldBe listOf<NavKey>(AccountDestination, AccountSettingsDestination)
+		viewModel.peekBackStack() shouldBe listOf(AccountDestination, AccountSettingsDestination)
 	}
 
 	@Test
 	fun `deep link to recipe opens recipe details on search tab`() {
 		val viewModel = mainViewModelForTest()
-		viewModel.onTabSelected(mainTabs.first { it.destination == FavoritesDestination })
+		viewModel.onTabSelected(mainTabs.first { it.destination is FavoritesDestination })
 		viewModel.onDeepLink(PurecipesLink.Recipe(99))
 
-		viewModel.peekBackStack() shouldBe listOf<NavKey>(SearchDestination(), RecipeDetailsDestination(99))
+		viewModel.peekBackStack() shouldBe listOf(SearchDestination(), RecipeDetailsDestination(99))
 	}
 
 	@Test
@@ -95,7 +95,7 @@ class MainViewModelTest {
 		viewModel.stageCookbookShareImport(sampleShareToken)
 
 		viewModel.peekBackStack() shouldBe listOf<NavKey>(SearchDestination())
-		viewModel.onTabSelected(mainTabs.first { it.destination == FavoritesDestination })
+		viewModel.onTabSelected(mainTabs.first { it.destination is FavoritesDestination })
 
 		viewModel.peekBackStack() shouldBe listOf<NavKey>(
 			FavoritesDestination(cookbookShareToken = sampleShareToken),
@@ -109,6 +109,6 @@ class MainViewModelTest {
 		viewModel.onStartCooking(42)
 		viewModel.onBack()
 
-		viewModel.peekBackStack() shouldBe listOf<NavKey>(SearchDestination(), RecipeDetailsDestination(42))
+		viewModel.peekBackStack() shouldBe listOf(SearchDestination(), RecipeDetailsDestination(42))
 	}
 }

--- a/feature/newrecipe/ui/src/commonMain/kotlin/app/purecipes/feature/newrecipe/ui/navigation/CreateNavigation.kt
+++ b/feature/newrecipe/ui/src/commonMain/kotlin/app/purecipes/feature/newrecipe/ui/navigation/CreateNavigation.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
 
-inline fun EntryProviderScope<NavKey>.installCreateFlow(
+fun EntryProviderScope<NavKey>.installCreateFlow(
 	canUploadRecipes: Boolean,
 ) {
 	entry<CreateDestination> {

--- a/feature/recipedetails/ui/src/commonMain/kotlin/app/purecipes/feature/recipedetails/ui/navigation/RecipeDetailsNavigation.kt
+++ b/feature/recipedetails/ui/src/commonMain/kotlin/app/purecipes/feature/recipedetails/ui/navigation/RecipeDetailsNavigation.kt
@@ -10,13 +10,13 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
 
-inline fun EntryProviderScope<NavKey>.installRecipeDetailsFlow(
+fun EntryProviderScope<NavKey>.installRecipeDetailsFlow(
 	navigator: Navigator,
 	canManageFavorites: Boolean,
 	sessionKey: String?,
-	noinline onFavoriteChange: () -> Unit,
-	noinline onStartCooking: (Int) -> Unit,
-	noinline onOpenMeasurementPreferences: () -> Unit,
+	onFavoriteChange: () -> Unit,
+	onStartCooking: (Int) -> Unit,
+	onOpenMeasurementPreferences: () -> Unit,
 ) {
 	entry<RecipeDetailsDestination> { destination ->
 		RecipeDetailsScreen(

--- a/feature/search/ui/src/commonMain/kotlin/app/purecipes/feature/search/ui/navigation/SearchDestination.kt
+++ b/feature/search/ui/src/commonMain/kotlin/app/purecipes/feature/search/ui/navigation/SearchDestination.kt
@@ -4,4 +4,6 @@ import androidx.navigation3.runtime.NavKey
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object SearchDestination : NavKey
+data class SearchDestination(
+	val openFiltersOnStart: Boolean = false,
+) : NavKey

--- a/feature/search/ui/src/commonMain/kotlin/app/purecipes/feature/search/ui/navigation/SearchNavigation.kt
+++ b/feature/search/ui/src/commonMain/kotlin/app/purecipes/feature/search/ui/navigation/SearchNavigation.kt
@@ -9,11 +9,11 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
 
-inline fun EntryProviderScope<NavKey>.installSearchFlow(
+fun EntryProviderScope<NavKey>.installSearchFlow(
 	isSignedIn: Boolean,
 	sessionKey: String?,
-	noinline onRecipeSelect: (Int) -> Unit,
-	noinline onRequestLogInForFilters: () -> Unit,
+	onRecipeSelect: (Int) -> Unit,
+	onRequestLogInForFilters: () -> Unit,
 ) {
 	entry<SearchDestination> { destination ->
 		RecipeSearchScreen(

--- a/feature/search/ui/src/commonMain/kotlin/app/purecipes/feature/search/ui/navigation/SearchNavigation.kt
+++ b/feature/search/ui/src/commonMain/kotlin/app/purecipes/feature/search/ui/navigation/SearchNavigation.kt
@@ -12,13 +12,12 @@ import kotlinx.serialization.modules.subclass
 inline fun EntryProviderScope<NavKey>.installSearchFlow(
 	isSignedIn: Boolean,
 	sessionKey: String?,
-	initialShowFilterSheet: Boolean,
 	noinline onRecipeSelect: (Int) -> Unit,
 	noinline onRequestLogInForFilters: () -> Unit,
 ) {
-	entry<SearchDestination> {
+	entry<SearchDestination> { destination ->
 		RecipeSearchScreen(
-			initialShowFilterSheet = initialShowFilterSheet,
+			initialShowFilterSheet = destination.openFiltersOnStart,
 			isSignedIn = isSignedIn,
 			modifier = Modifier.fillMaxSize(),
 			onRecipeSelect = onRecipeSelect,

--- a/feature/settings/ui/src/commonMain/kotlin/app/purecipes/feature/settings/ui/navigation/SettingsNavigation.kt
+++ b/feature/settings/ui/src/commonMain/kotlin/app/purecipes/feature/settings/ui/navigation/SettingsNavigation.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
 
-inline fun EntryProviderScope<NavKey>.installSettingsFlow(
+fun EntryProviderScope<NavKey>.installSettingsFlow(
 	navigator: Navigator,
 ) {
 	entry<AccountSettingsDestination> {


### PR DESCRIPTION
## Summary

- Model search filter sheet and cookbook share import intents on `SearchDestination` and `FavoritesDestination` so they survive back-stack save/restore.
- Remove `MainScreen` one-shot plumbing (`takePendingOpenSearchFilters`, `takePendingCookbookShareToken`) and drive navigation from `MainViewModel` via destination args.
- Update tab selection to match tab roots by type when destinations carry optional arguments.

Closes #129

## Test plan

- [x] `./gradlew detektAll`
- [x] `./gradlew :feature:main:jvmTest :feature:search:ui:jvmTest :feature:favorites:ui:jvmTest`
- [x] `./gradlew connectedAndroidTest`
- [ ] Post-login search opens filter sheet
- [ ] Cookbook share deep link imports on Favorites tab (signed in and after sign-in)