### PR TITLE
Drop pass-through use case providers in DataModules

### DIFF
--- a/build-logic/src/main/kotlin/convention/domain.gradle.kts
+++ b/build-logic/src/main/kotlin/convention/domain.gradle.kts
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 plugins {
 	id("convention.kmp")
+	id("dev.zacsweers.metro")
 }
 
 extensions.configure<KotlinMultiplatformExtension> {

--- a/feature/analytics/data/src/commonMain/kotlin/app/purecipes/feature/analytics/data/repository/AnalyticsDataModule.kt
+++ b/feature/analytics/data/src/commonMain/kotlin/app/purecipes/feature/analytics/data/repository/AnalyticsDataModule.kt
@@ -8,15 +8,6 @@ import app.purecipes.feature.analytics.data.datasource.PlatformConsentDataSource
 import app.purecipes.feature.analytics.domain.repository.AnalyticsRepository
 import app.purecipes.feature.analytics.domain.repository.ConsentRepository
 import app.purecipes.feature.analytics.domain.repository.CrashRepository
-import app.purecipes.feature.analytics.domain.usecase.LogBreadcrumbUseCase
-import app.purecipes.feature.analytics.domain.usecase.ObserveConsentStateUseCase
-import app.purecipes.feature.analytics.domain.usecase.RefreshConsentUseCase
-import app.purecipes.feature.analytics.domain.usecase.SendHandledExceptionUseCase
-import app.purecipes.feature.analytics.domain.usecase.SetAnalyticsUserIdUseCase
-import app.purecipes.feature.analytics.domain.usecase.SetCrashCustomValueUseCase
-import app.purecipes.feature.analytics.domain.usecase.SetCrashUserIdUseCase
-import app.purecipes.feature.analytics.domain.usecase.ShowConsentFormUseCase
-import app.purecipes.feature.analytics.domain.usecase.TrackEventUseCase
 import app.purecipes.shared.data.config.PurecipesConfig
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
@@ -45,52 +36,7 @@ interface AnalyticsDataModule {
 	}
 
 	@Provides
-	fun provideObserveConsentStateUseCase(repository: ConsentRepository): ObserveConsentStateUseCase {
-		return ObserveConsentStateUseCase(repository)
-	}
-
-	@Provides
-	fun provideRefreshConsentUseCase(repository: ConsentRepository): RefreshConsentUseCase {
-		return RefreshConsentUseCase(repository)
-	}
-
-	@Provides
-	fun provideShowConsentFormUseCase(repository: ConsentRepository): ShowConsentFormUseCase {
-		return ShowConsentFormUseCase(repository)
-	}
-
-	@Provides
-	fun provideTrackEventUseCase(repository: AnalyticsRepository): TrackEventUseCase {
-		return TrackEventUseCase(repository)
-	}
-
-	@Provides
-	fun provideSetAnalyticsUserIdUseCase(repository: AnalyticsRepository): SetAnalyticsUserIdUseCase {
-		return SetAnalyticsUserIdUseCase(repository)
-	}
-
-	@Provides
 	fun provideCrashRepository(): CrashRepository {
 		return CrashAccessor(CrashlyticsDataSource())
-	}
-
-	@Provides
-	fun provideLogBreadcrumbUseCase(repository: CrashRepository): LogBreadcrumbUseCase {
-		return LogBreadcrumbUseCase(repository)
-	}
-
-	@Provides
-	fun provideSendHandledExceptionUseCase(repository: CrashRepository): SendHandledExceptionUseCase {
-		return SendHandledExceptionUseCase(repository)
-	}
-
-	@Provides
-	fun provideSetCrashCustomValueUseCase(repository: CrashRepository): SetCrashCustomValueUseCase {
-		return SetCrashCustomValueUseCase(repository)
-	}
-
-	@Provides
-	fun provideSetCrashUserIdUseCase(repository: CrashRepository): SetCrashUserIdUseCase {
-		return SetCrashUserIdUseCase(repository)
 	}
 }

--- a/feature/analytics/domain/src/commonMain/kotlin/app/purecipes/feature/analytics/domain/usecase/LogBreadcrumbUseCase.kt
+++ b/feature/analytics/domain/src/commonMain/kotlin/app/purecipes/feature/analytics/domain/usecase/LogBreadcrumbUseCase.kt
@@ -1,7 +1,9 @@
 package app.purecipes.feature.analytics.domain.usecase
 
 import app.purecipes.feature.analytics.domain.repository.CrashRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class LogBreadcrumbUseCase(private val crashRepository: CrashRepository) {
 	operator fun invoke(message: String) {
 		crashRepository.logBreadcrumb(message)

--- a/feature/analytics/domain/src/commonMain/kotlin/app/purecipes/feature/analytics/domain/usecase/ObserveConsentStateUseCase.kt
+++ b/feature/analytics/domain/src/commonMain/kotlin/app/purecipes/feature/analytics/domain/usecase/ObserveConsentStateUseCase.kt
@@ -2,8 +2,10 @@ package app.purecipes.feature.analytics.domain.usecase
 
 import app.purecipes.feature.analytics.domain.model.ConsentState
 import app.purecipes.feature.analytics.domain.repository.ConsentRepository
+import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.StateFlow
 
+@Inject
 class ObserveConsentStateUseCase(
 	private val consentRepository: ConsentRepository,
 ) {

--- a/feature/analytics/domain/src/commonMain/kotlin/app/purecipes/feature/analytics/domain/usecase/RefreshConsentUseCase.kt
+++ b/feature/analytics/domain/src/commonMain/kotlin/app/purecipes/feature/analytics/domain/usecase/RefreshConsentUseCase.kt
@@ -1,7 +1,9 @@
 package app.purecipes.feature.analytics.domain.usecase
 
 import app.purecipes.feature.analytics.domain.repository.ConsentRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class RefreshConsentUseCase(
 	private val consentRepository: ConsentRepository,
 ) {

--- a/feature/analytics/domain/src/commonMain/kotlin/app/purecipes/feature/analytics/domain/usecase/SendHandledExceptionUseCase.kt
+++ b/feature/analytics/domain/src/commonMain/kotlin/app/purecipes/feature/analytics/domain/usecase/SendHandledExceptionUseCase.kt
@@ -1,7 +1,9 @@
 package app.purecipes.feature.analytics.domain.usecase
 
 import app.purecipes.feature.analytics.domain.repository.CrashRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class SendHandledExceptionUseCase(private val crashRepository: CrashRepository) {
 	operator fun invoke(throwable: Throwable) {
 		crashRepository.sendHandledException(throwable)

--- a/feature/analytics/domain/src/commonMain/kotlin/app/purecipes/feature/analytics/domain/usecase/SetAnalyticsUserIdUseCase.kt
+++ b/feature/analytics/domain/src/commonMain/kotlin/app/purecipes/feature/analytics/domain/usecase/SetAnalyticsUserIdUseCase.kt
@@ -1,7 +1,9 @@
 package app.purecipes.feature.analytics.domain.usecase
 
 import app.purecipes.feature.analytics.domain.repository.AnalyticsRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class SetAnalyticsUserIdUseCase(
 	private val analyticsRepository: AnalyticsRepository,
 ) {

--- a/feature/analytics/domain/src/commonMain/kotlin/app/purecipes/feature/analytics/domain/usecase/SetCrashCustomValueUseCase.kt
+++ b/feature/analytics/domain/src/commonMain/kotlin/app/purecipes/feature/analytics/domain/usecase/SetCrashCustomValueUseCase.kt
@@ -1,7 +1,9 @@
 package app.purecipes.feature.analytics.domain.usecase
 
 import app.purecipes.feature.analytics.domain.repository.CrashRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class SetCrashCustomValueUseCase(private val crashRepository: CrashRepository) {
 	operator fun invoke(key: String, value: String) {
 		crashRepository.setCustomValue(key, value)

--- a/feature/analytics/domain/src/commonMain/kotlin/app/purecipes/feature/analytics/domain/usecase/SetCrashUserIdUseCase.kt
+++ b/feature/analytics/domain/src/commonMain/kotlin/app/purecipes/feature/analytics/domain/usecase/SetCrashUserIdUseCase.kt
@@ -1,7 +1,9 @@
 package app.purecipes.feature.analytics.domain.usecase
 
 import app.purecipes.feature.analytics.domain.repository.CrashRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class SetCrashUserIdUseCase(private val crashRepository: CrashRepository) {
 	operator fun invoke(userId: String?) {
 		crashRepository.setUserId(userId)

--- a/feature/analytics/domain/src/commonMain/kotlin/app/purecipes/feature/analytics/domain/usecase/ShowConsentFormUseCase.kt
+++ b/feature/analytics/domain/src/commonMain/kotlin/app/purecipes/feature/analytics/domain/usecase/ShowConsentFormUseCase.kt
@@ -1,7 +1,9 @@
 package app.purecipes.feature.analytics.domain.usecase
 
 import app.purecipes.feature.analytics.domain.repository.ConsentRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class ShowConsentFormUseCase(
 	private val consentRepository: ConsentRepository,
 ) {

--- a/feature/analytics/domain/src/commonMain/kotlin/app/purecipes/feature/analytics/domain/usecase/TrackEventUseCase.kt
+++ b/feature/analytics/domain/src/commonMain/kotlin/app/purecipes/feature/analytics/domain/usecase/TrackEventUseCase.kt
@@ -2,7 +2,9 @@ package app.purecipes.feature.analytics.domain.usecase
 
 import app.purecipes.feature.analytics.domain.model.AnalyticsEvent
 import app.purecipes.feature.analytics.domain.repository.AnalyticsRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class TrackEventUseCase(
 	private val analyticsRepository: AnalyticsRepository,
 ) {

--- a/feature/auth/data/src/commonMain/kotlin/app/purecipes/feature/auth/data/repository/AuthenticationDataModule.kt
+++ b/feature/auth/data/src/commonMain/kotlin/app/purecipes/feature/auth/data/repository/AuthenticationDataModule.kt
@@ -7,15 +7,6 @@ import app.purecipes.feature.auth.data.datasource.AuthenticationStoreHolder
 import app.purecipes.feature.auth.data.datasource.FirebaseAuthenticationLocalDataSource
 import app.purecipes.feature.auth.domain.model.toAuthenticationState
 import app.purecipes.feature.auth.domain.repository.AuthenticationRepository
-import app.purecipes.feature.auth.domain.usecase.DeleteAccountUseCase
-import app.purecipes.feature.auth.domain.usecase.ObserveAuthenticationStateUseCase
-import app.purecipes.feature.auth.domain.usecase.RegisterWithEmailUseCase
-import app.purecipes.feature.auth.domain.usecase.ResendEmailVerificationUseCase
-import app.purecipes.feature.auth.domain.usecase.SendPasswordResetEmailUseCase
-import app.purecipes.feature.auth.domain.usecase.SignInWithEmailUseCase
-import app.purecipes.feature.auth.domain.usecase.SignInWithExternalProviderUseCase
-import app.purecipes.feature.auth.domain.usecase.SignInWithGoogleUseCase
-import app.purecipes.feature.auth.domain.usecase.SignOutUseCase
 import app.purecipes.shared.data.network.PurecipesApi
 import app.purecipes.shared.data.session.SessionTokenStore
 import dev.zacsweers.metro.AppScope
@@ -52,58 +43,5 @@ interface AuthenticationDataModule {
 		remoteDataSource: AuthenticationDataSource.Remote,
 	): AuthenticationRepository {
 		return AuthenticationAccessor(localDataSource, remoteDataSource)
-	}
-
-	@Provides
-	fun provideObserveAuthenticationStateUseCase(
-		repository: AuthenticationRepository
-	): ObserveAuthenticationStateUseCase {
-		return ObserveAuthenticationStateUseCase(repository)
-	}
-
-	@Provides
-	fun provideSignInWithEmailUseCase(repository: AuthenticationRepository): SignInWithEmailUseCase {
-		return SignInWithEmailUseCase(repository)
-	}
-
-	@Provides
-	fun provideRegisterWithEmailUseCase(repository: AuthenticationRepository): RegisterWithEmailUseCase {
-		return RegisterWithEmailUseCase(repository)
-	}
-
-	@Provides
-	fun provideResendEmailVerificationUseCase(
-		repository: AuthenticationRepository,
-	): ResendEmailVerificationUseCase {
-		return ResendEmailVerificationUseCase(repository)
-	}
-
-	@Provides
-	fun provideSendPasswordResetEmailUseCase(
-		repository: AuthenticationRepository,
-	): SendPasswordResetEmailUseCase {
-		return SendPasswordResetEmailUseCase(repository)
-	}
-
-	@Provides
-	fun provideSignInWithExternalProviderUseCase(
-		repository: AuthenticationRepository
-	): SignInWithExternalProviderUseCase {
-		return SignInWithExternalProviderUseCase(repository)
-	}
-
-	@Provides
-	fun provideSignInWithGoogleUseCase(repository: AuthenticationRepository): SignInWithGoogleUseCase {
-		return SignInWithGoogleUseCase(repository)
-	}
-
-	@Provides
-	fun provideDeleteAccountUseCase(repository: AuthenticationRepository): DeleteAccountUseCase {
-		return DeleteAccountUseCase(repository)
-	}
-
-	@Provides
-	fun provideSignOutUseCase(repository: AuthenticationRepository): SignOutUseCase {
-		return SignOutUseCase(repository)
 	}
 }

--- a/feature/auth/domain/src/commonMain/kotlin/app/purecipes/feature/auth/domain/usecase/DeleteAccountUseCase.kt
+++ b/feature/auth/domain/src/commonMain/kotlin/app/purecipes/feature/auth/domain/usecase/DeleteAccountUseCase.kt
@@ -2,7 +2,9 @@ package app.purecipes.feature.auth.domain.usecase
 
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.auth.domain.repository.AuthenticationRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class DeleteAccountUseCase(
 	private val repository: AuthenticationRepository,
 ) {

--- a/feature/auth/domain/src/commonMain/kotlin/app/purecipes/feature/auth/domain/usecase/ObserveAuthenticationStateUseCase.kt
+++ b/feature/auth/domain/src/commonMain/kotlin/app/purecipes/feature/auth/domain/usecase/ObserveAuthenticationStateUseCase.kt
@@ -2,8 +2,10 @@ package app.purecipes.feature.auth.domain.usecase
 
 import app.purecipes.feature.auth.domain.model.AuthenticationState
 import app.purecipes.feature.auth.domain.repository.AuthenticationRepository
+import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.StateFlow
 
+@Inject
 class ObserveAuthenticationStateUseCase(
 	private val repository: AuthenticationRepository,
 ) {

--- a/feature/auth/domain/src/commonMain/kotlin/app/purecipes/feature/auth/domain/usecase/RegisterWithEmailUseCase.kt
+++ b/feature/auth/domain/src/commonMain/kotlin/app/purecipes/feature/auth/domain/usecase/RegisterWithEmailUseCase.kt
@@ -4,7 +4,9 @@ import app.purecipes.base.kotlin.result.Failure
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.auth.domain.repository.AuthenticationRepository
 import com.github.michaelbull.result.Err
+import dev.zacsweers.metro.Inject
 
+@Inject
 class RegisterWithEmailUseCase(
 	private val repository: AuthenticationRepository,
 ) {

--- a/feature/auth/domain/src/commonMain/kotlin/app/purecipes/feature/auth/domain/usecase/ResendEmailVerificationUseCase.kt
+++ b/feature/auth/domain/src/commonMain/kotlin/app/purecipes/feature/auth/domain/usecase/ResendEmailVerificationUseCase.kt
@@ -4,7 +4,9 @@ import app.purecipes.base.kotlin.result.Failure
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.auth.domain.repository.AuthenticationRepository
 import com.github.michaelbull.result.Err
+import dev.zacsweers.metro.Inject
 
+@Inject
 class ResendEmailVerificationUseCase(
 	private val repository: AuthenticationRepository,
 ) {

--- a/feature/auth/domain/src/commonMain/kotlin/app/purecipes/feature/auth/domain/usecase/SendPasswordResetEmailUseCase.kt
+++ b/feature/auth/domain/src/commonMain/kotlin/app/purecipes/feature/auth/domain/usecase/SendPasswordResetEmailUseCase.kt
@@ -4,7 +4,9 @@ import app.purecipes.base.kotlin.result.Failure
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.auth.domain.repository.AuthenticationRepository
 import com.github.michaelbull.result.Err
+import dev.zacsweers.metro.Inject
 
+@Inject
 class SendPasswordResetEmailUseCase(
 	private val repository: AuthenticationRepository,
 ) {

--- a/feature/auth/domain/src/commonMain/kotlin/app/purecipes/feature/auth/domain/usecase/SignInWithEmailUseCase.kt
+++ b/feature/auth/domain/src/commonMain/kotlin/app/purecipes/feature/auth/domain/usecase/SignInWithEmailUseCase.kt
@@ -5,7 +5,9 @@ import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.auth.domain.model.AuthUser
 import app.purecipes.feature.auth.domain.repository.AuthenticationRepository
 import com.github.michaelbull.result.Err
+import dev.zacsweers.metro.Inject
 
+@Inject
 class SignInWithEmailUseCase(
 	private val repository: AuthenticationRepository,
 ) {

--- a/feature/auth/domain/src/commonMain/kotlin/app/purecipes/feature/auth/domain/usecase/SignInWithExternalProviderUseCase.kt
+++ b/feature/auth/domain/src/commonMain/kotlin/app/purecipes/feature/auth/domain/usecase/SignInWithExternalProviderUseCase.kt
@@ -7,7 +7,9 @@ import app.purecipes.feature.auth.domain.model.AuthUser
 import app.purecipes.feature.auth.domain.model.ExternalAuthenticationProfile
 import app.purecipes.feature.auth.domain.repository.AuthenticationRepository
 import com.github.michaelbull.result.Err
+import dev.zacsweers.metro.Inject
 
+@Inject
 class SignInWithExternalProviderUseCase(
 	private val repository: AuthenticationRepository,
 ) {

--- a/feature/auth/domain/src/commonMain/kotlin/app/purecipes/feature/auth/domain/usecase/SignInWithGoogleUseCase.kt
+++ b/feature/auth/domain/src/commonMain/kotlin/app/purecipes/feature/auth/domain/usecase/SignInWithGoogleUseCase.kt
@@ -6,7 +6,9 @@ import app.purecipes.feature.auth.domain.model.AuthUser
 import app.purecipes.feature.auth.domain.model.GoogleAuthenticationProfile
 import app.purecipes.feature.auth.domain.repository.AuthenticationRepository
 import com.github.michaelbull.result.Err
+import dev.zacsweers.metro.Inject
 
+@Inject
 class SignInWithGoogleUseCase(
 	private val repository: AuthenticationRepository,
 ) {

--- a/feature/auth/domain/src/commonMain/kotlin/app/purecipes/feature/auth/domain/usecase/SignOutUseCase.kt
+++ b/feature/auth/domain/src/commonMain/kotlin/app/purecipes/feature/auth/domain/usecase/SignOutUseCase.kt
@@ -1,7 +1,9 @@
 package app.purecipes.feature.auth.domain.usecase
 
 import app.purecipes.feature.auth.domain.repository.AuthenticationRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class SignOutUseCase(
 	private val repository: AuthenticationRepository,
 ) {

--- a/feature/favorites/data/src/commonMain/kotlin/app/purecipes/feature/favorites/data/repository/FavoritesDataModule.kt
+++ b/feature/favorites/data/src/commonMain/kotlin/app/purecipes/feature/favorites/data/repository/FavoritesDataModule.kt
@@ -9,17 +9,6 @@ import app.purecipes.feature.favorites.data.datasource.SettingsCookbookCoverLoca
 import app.purecipes.feature.favorites.domain.repository.CookbookCoverRepository
 import app.purecipes.feature.favorites.domain.repository.CookbooksRepository
 import app.purecipes.feature.favorites.domain.repository.FavoritesRepository
-import app.purecipes.feature.favorites.domain.usecase.AddFavoriteRecipeUseCase
-import app.purecipes.feature.favorites.domain.usecase.AddRecipeToCookbookUseCase
-import app.purecipes.feature.favorites.domain.usecase.CreateCookbookUseCase
-import app.purecipes.feature.favorites.domain.usecase.DeleteCookbookUseCase
-import app.purecipes.feature.favorites.domain.usecase.GetCookbookCoverImageUrlUseCase
-import app.purecipes.feature.favorites.domain.usecase.GetCookbookRecipesPageUseCase
-import app.purecipes.feature.favorites.domain.usecase.GetCookbooksPageUseCase
-import app.purecipes.feature.favorites.domain.usecase.GetFavoriteRecipesPageUseCase
-import app.purecipes.feature.favorites.domain.usecase.GetRecipeCookbooksUseCase
-import app.purecipes.feature.favorites.domain.usecase.RemoveFavoriteRecipeUseCase
-import app.purecipes.feature.favorites.domain.usecase.RemoveRecipeFromCookbookUseCase
 import app.purecipes.shared.data.network.PurecipesApi
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
@@ -49,56 +38,6 @@ interface FavoritesDataModule {
 	}
 
 	@Provides
-	fun provideAddFavoriteRecipeUseCase(repository: FavoritesRepository): AddFavoriteRecipeUseCase {
-		return AddFavoriteRecipeUseCase(repository)
-	}
-
-	@Provides
-	fun provideGetFavoriteRecipesPageUseCase(repository: FavoritesRepository): GetFavoriteRecipesPageUseCase {
-		return GetFavoriteRecipesPageUseCase(repository)
-	}
-
-	@Provides
-	fun provideRemoveFavoriteRecipeUseCase(repository: FavoritesRepository): RemoveFavoriteRecipeUseCase {
-		return RemoveFavoriteRecipeUseCase(repository)
-	}
-
-	@Provides
-	fun provideGetCookbooksPageUseCase(repository: CookbooksRepository): GetCookbooksPageUseCase {
-		return GetCookbooksPageUseCase(repository)
-	}
-
-	@Provides
-	fun provideCreateCookbookUseCase(repository: CookbooksRepository): CreateCookbookUseCase {
-		return CreateCookbookUseCase(repository)
-	}
-
-	@Provides
-	fun provideDeleteCookbookUseCase(repository: CookbooksRepository): DeleteCookbookUseCase {
-		return DeleteCookbookUseCase(repository)
-	}
-
-	@Provides
-	fun provideGetCookbookRecipesPageUseCase(repository: CookbooksRepository): GetCookbookRecipesPageUseCase {
-		return GetCookbookRecipesPageUseCase(repository)
-	}
-
-	@Provides
-	fun provideAddRecipeToCookbookUseCase(repository: CookbooksRepository): AddRecipeToCookbookUseCase {
-		return AddRecipeToCookbookUseCase(repository)
-	}
-
-	@Provides
-	fun provideRemoveRecipeFromCookbookUseCase(repository: CookbooksRepository): RemoveRecipeFromCookbookUseCase {
-		return RemoveRecipeFromCookbookUseCase(repository)
-	}
-
-	@Provides
-	fun provideGetRecipeCookbooksUseCase(repository: CookbooksRepository): GetRecipeCookbooksUseCase {
-		return GetRecipeCookbooksUseCase(repository)
-	}
-
-	@Provides
 	fun provideCookbookCoverLocalDataSource(): CookbookCoverDataSource.Local {
 		return SettingsCookbookCoverLocalDataSource()
 	}
@@ -108,12 +47,5 @@ interface FavoritesDataModule {
 		localDataSource: CookbookCoverDataSource.Local,
 	): CookbookCoverRepository {
 		return CookbookCoverAccessor(localDataSource)
-	}
-
-	@Provides
-	fun provideGetCookbookCoverImageUrlUseCase(
-		repository: CookbookCoverRepository,
-	): GetCookbookCoverImageUrlUseCase {
-		return GetCookbookCoverImageUrlUseCase(repository)
 	}
 }

--- a/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/AddFavoriteRecipeUseCase.kt
+++ b/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/AddFavoriteRecipeUseCase.kt
@@ -2,7 +2,9 @@ package app.purecipes.feature.favorites.domain.usecase
 
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.favorites.domain.repository.FavoritesRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class AddFavoriteRecipeUseCase(
 	private val repository: FavoritesRepository,
 ) {

--- a/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/AddRecipeToCookbookUseCase.kt
+++ b/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/AddRecipeToCookbookUseCase.kt
@@ -2,7 +2,9 @@ package app.purecipes.feature.favorites.domain.usecase
 
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.favorites.domain.repository.CookbooksRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class AddRecipeToCookbookUseCase(
 	private val repository: CookbooksRepository,
 ) {

--- a/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/CreateCookbookUseCase.kt
+++ b/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/CreateCookbookUseCase.kt
@@ -3,7 +3,9 @@ package app.purecipes.feature.favorites.domain.usecase
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.favorites.domain.repository.CookbooksRepository
 import app.purecipes.shared.domain.model.CookbookSummary
+import dev.zacsweers.metro.Inject
 
+@Inject
 class CreateCookbookUseCase(
 	private val repository: CookbooksRepository,
 ) {

--- a/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/DeleteCookbookUseCase.kt
+++ b/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/DeleteCookbookUseCase.kt
@@ -2,7 +2,9 @@ package app.purecipes.feature.favorites.domain.usecase
 
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.favorites.domain.repository.CookbooksRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class DeleteCookbookUseCase(
 	private val repository: CookbooksRepository,
 ) {

--- a/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/GetCookbookCoverImageUrlUseCase.kt
+++ b/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/GetCookbookCoverImageUrlUseCase.kt
@@ -1,8 +1,10 @@
 package app.purecipes.feature.favorites.domain.usecase
 
 import app.purecipes.feature.favorites.domain.repository.CookbookCoverRepository
+import dev.zacsweers.metro.Inject
 import kotlin.random.Random
 
+@Inject
 class GetCookbookCoverImageUrlUseCase(
 	private val repository: CookbookCoverRepository,
 ) {

--- a/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/GetCookbookRecipesPageUseCase.kt
+++ b/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/GetCookbookRecipesPageUseCase.kt
@@ -3,7 +3,9 @@ package app.purecipes.feature.favorites.domain.usecase
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.favorites.domain.repository.CookbooksRepository
 import app.purecipes.shared.domain.model.SearchResultsPage
+import dev.zacsweers.metro.Inject
 
+@Inject
 class GetCookbookRecipesPageUseCase(
 	private val repository: CookbooksRepository,
 ) {

--- a/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/GetCookbooksPageUseCase.kt
+++ b/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/GetCookbooksPageUseCase.kt
@@ -3,7 +3,9 @@ package app.purecipes.feature.favorites.domain.usecase
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.favorites.domain.repository.CookbooksRepository
 import app.purecipes.shared.domain.model.CookbookListPage
+import dev.zacsweers.metro.Inject
 
+@Inject
 class GetCookbooksPageUseCase(
 	private val repository: CookbooksRepository,
 ) {

--- a/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/GetFavoriteRecipesPageUseCase.kt
+++ b/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/GetFavoriteRecipesPageUseCase.kt
@@ -3,7 +3,9 @@ package app.purecipes.feature.favorites.domain.usecase
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.favorites.domain.repository.FavoritesRepository
 import app.purecipes.shared.domain.model.SearchResultsPage
+import dev.zacsweers.metro.Inject
 
+@Inject
 class GetFavoriteRecipesPageUseCase(
 	private val repository: FavoritesRepository,
 ) {

--- a/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/GetRecipeCookbooksUseCase.kt
+++ b/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/GetRecipeCookbooksUseCase.kt
@@ -3,7 +3,9 @@ package app.purecipes.feature.favorites.domain.usecase
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.favorites.domain.repository.CookbooksRepository
 import app.purecipes.shared.domain.model.CookbookRef
+import dev.zacsweers.metro.Inject
 
+@Inject
 class GetRecipeCookbooksUseCase(
 	private val repository: CookbooksRepository,
 ) {

--- a/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/RemoveFavoriteRecipeUseCase.kt
+++ b/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/RemoveFavoriteRecipeUseCase.kt
@@ -2,7 +2,9 @@ package app.purecipes.feature.favorites.domain.usecase
 
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.favorites.domain.repository.FavoritesRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class RemoveFavoriteRecipeUseCase(
 	private val repository: FavoritesRepository,
 ) {

--- a/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/RemoveRecipeFromCookbookUseCase.kt
+++ b/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/RemoveRecipeFromCookbookUseCase.kt
@@ -2,7 +2,9 @@ package app.purecipes.feature.favorites.domain.usecase
 
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.favorites.domain.repository.CookbooksRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class RemoveRecipeFromCookbookUseCase(
 	private val repository: CookbooksRepository,
 ) {

--- a/feature/main/src/commonTest/kotlin/app/purecipes/feature/main/ui/MainViewModelStartTest.kt
+++ b/feature/main/src/commonTest/kotlin/app/purecipes/feature/main/ui/MainViewModelStartTest.kt
@@ -5,6 +5,7 @@ import app.purecipes.feature.auth.domain.model.AuthProvider
 import app.purecipes.feature.auth.domain.model.AuthenticationState
 import app.purecipes.feature.auth.domain.model.GoogleAuthenticationProfile
 import app.purecipes.feature.auth.ui.navigation.AccountDestination
+import app.purecipes.feature.favorites.ui.navigation.FavoritesDestination
 import app.purecipes.feature.recipedetails.ui.navigation.RecipeDetailsDestination
 import app.purecipes.feature.search.ui.navigation.SearchDestination
 import app.purecipes.feature.sharing.domain.model.PurecipesLink

--- a/feature/newrecipe/data/src/commonMain/kotlin/app/purecipes/feature/newrecipe/data/repository/NewRecipeDataModule.kt
+++ b/feature/newrecipe/data/src/commonMain/kotlin/app/purecipes/feature/newrecipe/data/repository/NewRecipeDataModule.kt
@@ -10,9 +10,6 @@ import app.purecipes.feature.newrecipe.data.image.RecipeImageRemoteUploader
 import app.purecipes.feature.newrecipe.data.image.RecipeImageUploader
 import app.purecipes.feature.newrecipe.domain.repository.CreatedRecipeRepository
 import app.purecipes.feature.newrecipe.domain.repository.RecipeNutritionEstimateRepository
-import app.purecipes.feature.newrecipe.domain.usecase.EstimateRecipeNutritionUseCase
-import app.purecipes.feature.newrecipe.domain.usecase.GetCreatedRecipesUseCase
-import app.purecipes.feature.newrecipe.domain.usecase.SaveCreatedRecipeUseCase
 import app.purecipes.shared.data.config.PurecipesConfig
 import app.purecipes.shared.data.network.PurecipesApi
 import dev.zacsweers.metro.AppScope
@@ -52,16 +49,6 @@ interface NewRecipeDataModule {
 	}
 
 	@Provides
-	fun provideGetCreatedRecipesUseCase(repository: CreatedRecipeRepository): GetCreatedRecipesUseCase {
-		return GetCreatedRecipesUseCase(repository)
-	}
-
-	@Provides
-	fun provideSaveCreatedRecipeUseCase(repository: CreatedRecipeRepository): SaveCreatedRecipeUseCase {
-		return SaveCreatedRecipeUseCase(repository)
-	}
-
-	@Provides
 	fun provideRecipeNutritionEstimateRemoteDataSource(api: PurecipesApi): RecipeNutritionEstimateDataSource.Remote {
 		return RecipeNutritionEstimateRemoteDataSource(api)
 	}
@@ -71,12 +58,5 @@ interface NewRecipeDataModule {
 		remoteDataSource: RecipeNutritionEstimateDataSource.Remote,
 	): RecipeNutritionEstimateRepository {
 		return RecipeNutritionEstimateAccessor(remoteDataSource)
-	}
-
-	@Provides
-	fun provideEstimateRecipeNutritionUseCase(
-		repository: RecipeNutritionEstimateRepository,
-	): EstimateRecipeNutritionUseCase {
-		return EstimateRecipeNutritionUseCase(repository)
 	}
 }

--- a/feature/newrecipe/domain/src/commonMain/kotlin/app/purecipes/feature/newrecipe/domain/usecase/EstimateRecipeNutritionUseCase.kt
+++ b/feature/newrecipe/domain/src/commonMain/kotlin/app/purecipes/feature/newrecipe/domain/usecase/EstimateRecipeNutritionUseCase.kt
@@ -3,7 +3,9 @@ package app.purecipes.feature.newrecipe.domain.usecase
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.newrecipe.domain.repository.RecipeNutritionEstimateRepository
 import app.purecipes.shared.domain.model.NutritionSummary
+import dev.zacsweers.metro.Inject
 
+@Inject
 class EstimateRecipeNutritionUseCase(
 	private val repository: RecipeNutritionEstimateRepository,
 ) {

--- a/feature/newrecipe/domain/src/commonMain/kotlin/app/purecipes/feature/newrecipe/domain/usecase/GetCreatedRecipesUseCase.kt
+++ b/feature/newrecipe/domain/src/commonMain/kotlin/app/purecipes/feature/newrecipe/domain/usecase/GetCreatedRecipesUseCase.kt
@@ -3,7 +3,9 @@ package app.purecipes.feature.newrecipe.domain.usecase
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.newrecipe.domain.repository.CreatedRecipeRepository
 import app.purecipes.shared.domain.model.RecipeDetails
+import dev.zacsweers.metro.Inject
 
+@Inject
 class GetCreatedRecipesUseCase(
 	private val repository: CreatedRecipeRepository,
 ) {

--- a/feature/newrecipe/domain/src/commonMain/kotlin/app/purecipes/feature/newrecipe/domain/usecase/SaveCreatedRecipeUseCase.kt
+++ b/feature/newrecipe/domain/src/commonMain/kotlin/app/purecipes/feature/newrecipe/domain/usecase/SaveCreatedRecipeUseCase.kt
@@ -4,7 +4,9 @@ import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.newrecipe.domain.model.SaveCreatedRecipeRequest
 import app.purecipes.feature.newrecipe.domain.repository.CreatedRecipeRepository
 import app.purecipes.shared.domain.model.RecipeDetails
+import dev.zacsweers.metro.Inject
 
+@Inject
 class SaveCreatedRecipeUseCase(
 	private val repository: CreatedRecipeRepository,
 ) {

--- a/feature/recipedetails/data/src/commonMain/kotlin/app/purecipes/feature/recipedetails/data/repository/RecipeDetailsDataModule.kt
+++ b/feature/recipedetails/data/src/commonMain/kotlin/app/purecipes/feature/recipedetails/data/repository/RecipeDetailsDataModule.kt
@@ -3,7 +3,6 @@ package app.purecipes.feature.recipedetails.data.repository
 import app.purecipes.feature.recipedetails.data.datasource.RecipeDetailsDataSource
 import app.purecipes.feature.recipedetails.data.datasource.RecipeDetailsRemoteDataSource
 import app.purecipes.feature.recipedetails.domain.repository.RecipeDetailsRepository
-import app.purecipes.feature.recipedetails.domain.usecase.GetRecipeDetailsUseCase
 import app.purecipes.shared.data.network.PurecipesApi
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
@@ -20,10 +19,5 @@ interface RecipeDetailsDataModule {
 	@Provides
 	fun provideRecipeDetailsRepository(remoteDataSource: RecipeDetailsDataSource.Remote): RecipeDetailsRepository {
 		return RecipeDetailsAccessor(remoteDataSource)
-	}
-
-	@Provides
-	fun provideGetRecipeDetailsUseCase(repository: RecipeDetailsRepository): GetRecipeDetailsUseCase {
-		return GetRecipeDetailsUseCase(repository)
 	}
 }

--- a/feature/recipedetails/domain/src/commonMain/kotlin/app/purecipes/feature/recipedetails/domain/usecase/GetRecipeDetailsUseCase.kt
+++ b/feature/recipedetails/domain/src/commonMain/kotlin/app/purecipes/feature/recipedetails/domain/usecase/GetRecipeDetailsUseCase.kt
@@ -3,7 +3,9 @@ package app.purecipes.feature.recipedetails.domain.usecase
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.recipedetails.domain.repository.RecipeDetailsRepository
 import app.purecipes.shared.domain.model.RecipeDetails
+import dev.zacsweers.metro.Inject
 
+@Inject
 class GetRecipeDetailsUseCase(
 	private val repository: RecipeDetailsRepository,
 ) {

--- a/feature/search/data/src/commonMain/kotlin/app/purecipes/feature/search/data/repository/SearchDataModule.kt
+++ b/feature/search/data/src/commonMain/kotlin/app/purecipes/feature/search/data/repository/SearchDataModule.kt
@@ -11,11 +11,6 @@ import app.purecipes.feature.search.data.datasource.UserPantryRemoteDataSource
 import app.purecipes.feature.search.domain.repository.RecipeSearchFilterRepository
 import app.purecipes.feature.search.domain.repository.RecipeSearchRepository
 import app.purecipes.feature.search.domain.repository.UserPantryRepository
-import app.purecipes.feature.search.domain.usecase.GetSearchFiltersUseCase
-import app.purecipes.feature.search.domain.usecase.GetUserPantryUseCase
-import app.purecipes.feature.search.domain.usecase.SaveSearchFiltersUseCase
-import app.purecipes.feature.search.domain.usecase.SearchRecipesUseCase
-import app.purecipes.feature.search.domain.usecase.UpdateUserPantryUseCase
 import app.purecipes.shared.data.network.PurecipesApi
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
@@ -31,11 +26,6 @@ interface SearchDataModule {
 	@Provides
 	fun provideRecipeSearchRepository(remoteDataSource: RecipeSearchDataSource.Remote): RecipeSearchRepository {
 		return RecipeSearchAccessor(remoteDataSource)
-	}
-
-	@Provides
-	fun provideSearchRecipesUseCase(repository: RecipeSearchRepository): SearchRecipesUseCase {
-		return SearchRecipesUseCase(repository)
 	}
 
 	@Provides
@@ -57,16 +47,6 @@ interface SearchDataModule {
 	}
 
 	@Provides
-	fun provideGetSearchFiltersUseCase(repository: RecipeSearchFilterRepository): GetSearchFiltersUseCase {
-		return GetSearchFiltersUseCase(repository)
-	}
-
-	@Provides
-	fun provideSaveSearchFiltersUseCase(repository: RecipeSearchFilterRepository): SaveSearchFiltersUseCase {
-		return SaveSearchFiltersUseCase(repository)
-	}
-
-	@Provides
 	fun provideUserPantryRemoteDataSource(api: PurecipesApi): UserPantryDataSource.Remote {
 		return UserPantryRemoteDataSource(api)
 	}
@@ -82,15 +62,5 @@ interface SearchDataModule {
 		localDataSource: UserPantryDataSource.Local,
 	): UserPantryRepository {
 		return UserPantryAccessor(remoteDataSource, localDataSource)
-	}
-
-	@Provides
-	fun provideGetUserPantryUseCase(repository: UserPantryRepository): GetUserPantryUseCase {
-		return GetUserPantryUseCase(repository)
-	}
-
-	@Provides
-	fun provideUpdateUserPantryUseCase(repository: UserPantryRepository): UpdateUserPantryUseCase {
-		return UpdateUserPantryUseCase(repository)
 	}
 }

--- a/feature/search/domain/src/commonMain/kotlin/app/purecipes/feature/search/domain/usecase/GetSearchFiltersUseCase.kt
+++ b/feature/search/domain/src/commonMain/kotlin/app/purecipes/feature/search/domain/usecase/GetSearchFiltersUseCase.kt
@@ -2,7 +2,9 @@ package app.purecipes.feature.search.domain.usecase
 
 import app.purecipes.feature.search.domain.repository.RecipeSearchFilterRepository
 import app.purecipes.shared.domain.model.SearchFilters
+import dev.zacsweers.metro.Inject
 
+@Inject
 class GetSearchFiltersUseCase(
 	private val repository: RecipeSearchFilterRepository,
 ) {

--- a/feature/search/domain/src/commonMain/kotlin/app/purecipes/feature/search/domain/usecase/GetUserPantryUseCase.kt
+++ b/feature/search/domain/src/commonMain/kotlin/app/purecipes/feature/search/domain/usecase/GetUserPantryUseCase.kt
@@ -1,7 +1,9 @@
 package app.purecipes.feature.search.domain.usecase
 
 import app.purecipes.feature.search.domain.repository.UserPantryRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class GetUserPantryUseCase(
 	private val repository: UserPantryRepository,
 ) {

--- a/feature/search/domain/src/commonMain/kotlin/app/purecipes/feature/search/domain/usecase/SaveSearchFiltersUseCase.kt
+++ b/feature/search/domain/src/commonMain/kotlin/app/purecipes/feature/search/domain/usecase/SaveSearchFiltersUseCase.kt
@@ -2,7 +2,9 @@ package app.purecipes.feature.search.domain.usecase
 
 import app.purecipes.feature.search.domain.repository.RecipeSearchFilterRepository
 import app.purecipes.shared.domain.model.SearchFilters
+import dev.zacsweers.metro.Inject
 
+@Inject
 class SaveSearchFiltersUseCase(
 	private val repository: RecipeSearchFilterRepository,
 ) {

--- a/feature/search/domain/src/commonMain/kotlin/app/purecipes/feature/search/domain/usecase/SearchRecipesUseCase.kt
+++ b/feature/search/domain/src/commonMain/kotlin/app/purecipes/feature/search/domain/usecase/SearchRecipesUseCase.kt
@@ -4,7 +4,9 @@ import app.purecipes.feature.search.domain.repository.RecipeSearchRepository
 import app.purecipes.feature.search.domain.repository.SearchOutcome
 import app.purecipes.shared.domain.model.SearchFilters
 import app.purecipes.shared.domain.model.SearchResultsPage
+import dev.zacsweers.metro.Inject
 
+@Inject
 class SearchRecipesUseCase(
 	private val repository: RecipeSearchRepository,
 ) {

--- a/feature/search/domain/src/commonMain/kotlin/app/purecipes/feature/search/domain/usecase/UpdateUserPantryUseCase.kt
+++ b/feature/search/domain/src/commonMain/kotlin/app/purecipes/feature/search/domain/usecase/UpdateUserPantryUseCase.kt
@@ -2,7 +2,9 @@ package app.purecipes.feature.search.domain.usecase
 
 import app.purecipes.feature.search.domain.repository.UserPantryRepository
 import app.purecipes.shared.domain.model.PantryDelta
+import dev.zacsweers.metro.Inject
 
+@Inject
 class UpdateUserPantryUseCase(
 	private val repository: UserPantryRepository,
 ) {

--- a/feature/settings/data/src/commonMain/kotlin/app/purecipes/feature/settings/data/repository/SettingsDataModule.kt
+++ b/feature/settings/data/src/commonMain/kotlin/app/purecipes/feature/settings/data/repository/SettingsDataModule.kt
@@ -1,13 +1,6 @@
 package app.purecipes.feature.settings.data.repository
 
 import app.purecipes.feature.measurement.domain.repository.MeasurementPreferencesRepository
-import app.purecipes.feature.measurement.domain.usecase.FilterRecipesForMeasurementPreferencesUseCase
-import app.purecipes.feature.measurement.domain.usecase.GetMeasurementPreferencesUseCase
-import app.purecipes.feature.measurement.domain.usecase.MarkMeasurementMismatchSeenUseCase
-import app.purecipes.feature.measurement.domain.usecase.ObserveMeasurementPreferencesUseCase
-import app.purecipes.feature.measurement.domain.usecase.ProcessRecipeDetailsForMeasurementPreferencesUseCase
-import app.purecipes.feature.measurement.domain.usecase.ResetMeasurementPreferencesUseCase
-import app.purecipes.feature.measurement.domain.usecase.SaveMeasurementPreferencesUseCase
 import app.purecipes.feature.settings.data.datasource.MeasurementPreferencesDataSource
 import app.purecipes.feature.settings.data.datasource.MeasurementPreferencesRemoteDataSource
 import app.purecipes.feature.settings.data.datasource.NotificationPreferencesDataSource
@@ -15,10 +8,6 @@ import app.purecipes.feature.settings.data.datasource.PurecipesMeasurementPrefer
 import app.purecipes.feature.settings.data.datasource.SettingsMeasurementPreferencesDataSource
 import app.purecipes.feature.settings.data.datasource.SettingsNotificationPreferencesDataSource
 import app.purecipes.feature.settings.domain.repository.NotificationPreferencesRepository
-import app.purecipes.feature.settings.domain.usecase.InitializeNotificationsUseCase
-import app.purecipes.feature.settings.domain.usecase.ObserveNotificationPreferencesUseCase
-import app.purecipes.feature.settings.domain.usecase.SaveNotificationPreferencesUseCase
-import app.purecipes.feature.settings.domain.usecase.SendTestNotificationUseCase
 import app.purecipes.shared.data.network.PurecipesApi
 import app.purecipes.shared.data.notification.KmpNotificationManager
 import app.purecipes.shared.data.session.SessionTokenStore
@@ -54,52 +43,6 @@ interface SettingsDataModule {
 	}
 
 	@Provides
-	fun provideObserveMeasurementPreferencesUseCase(
-		repository: MeasurementPreferencesRepository,
-	): ObserveMeasurementPreferencesUseCase {
-		return ObserveMeasurementPreferencesUseCase(repository)
-	}
-
-	@Provides
-	fun provideGetMeasurementPreferencesUseCase(
-		repository: MeasurementPreferencesRepository,
-	): GetMeasurementPreferencesUseCase {
-		return GetMeasurementPreferencesUseCase(repository)
-	}
-
-	@Provides
-	fun provideSaveMeasurementPreferencesUseCase(
-		repository: MeasurementPreferencesRepository,
-	): SaveMeasurementPreferencesUseCase {
-		return SaveMeasurementPreferencesUseCase(repository)
-	}
-
-	@Provides
-	fun provideResetMeasurementPreferencesUseCase(
-		repository: MeasurementPreferencesRepository,
-	): ResetMeasurementPreferencesUseCase {
-		return ResetMeasurementPreferencesUseCase(repository)
-	}
-
-	@Provides
-	fun provideMarkMeasurementMismatchSeenUseCase(
-		repository: MeasurementPreferencesRepository,
-	): MarkMeasurementMismatchSeenUseCase {
-		return MarkMeasurementMismatchSeenUseCase(repository)
-	}
-
-	@Provides
-	fun provideProcessRecipeDetailsForMeasurementPreferencesUseCase():
-		ProcessRecipeDetailsForMeasurementPreferencesUseCase {
-		return ProcessRecipeDetailsForMeasurementPreferencesUseCase()
-	}
-
-	@Provides
-	fun provideFilterRecipesForMeasurementPreferencesUseCase(): FilterRecipesForMeasurementPreferencesUseCase {
-		return FilterRecipesForMeasurementPreferencesUseCase()
-	}
-
-	@Provides
 	fun provideNotificationPreferencesDataSource(): NotificationPreferencesDataSource {
 		return SettingsNotificationPreferencesDataSource()
 	}
@@ -116,34 +59,5 @@ interface SettingsDataModule {
 		kmpNotificationManager: KmpNotificationManager,
 	): NotificationManager {
 		return kmpNotificationManager
-	}
-
-	@Provides
-	fun provideInitializeNotificationsUseCase(
-		notificationManager: NotificationManager,
-	): InitializeNotificationsUseCase {
-		return InitializeNotificationsUseCase(notificationManager)
-	}
-
-	@Provides
-	fun provideSendTestNotificationUseCase(
-		notificationManager: NotificationManager,
-	): SendTestNotificationUseCase {
-		return SendTestNotificationUseCase(notificationManager)
-	}
-
-	@Provides
-	fun provideObserveNotificationPreferencesUseCase(
-		repository: NotificationPreferencesRepository,
-	): ObserveNotificationPreferencesUseCase {
-		return ObserveNotificationPreferencesUseCase(repository)
-	}
-
-	@Provides
-	fun provideSaveNotificationPreferencesUseCase(
-		repository: NotificationPreferencesRepository,
-		notificationManager: NotificationManager,
-	): SaveNotificationPreferencesUseCase {
-		return SaveNotificationPreferencesUseCase(repository, notificationManager)
 	}
 }

--- a/feature/settings/domain/src/commonMain/kotlin/app/purecipes/feature/measurement/domain/usecase/FilterRecipesForMeasurementPreferencesUseCase.kt
+++ b/feature/settings/domain/src/commonMain/kotlin/app/purecipes/feature/measurement/domain/usecase/FilterRecipesForMeasurementPreferencesUseCase.kt
@@ -4,7 +4,9 @@ import app.purecipes.shared.domain.model.MeasurementPreferences
 import app.purecipes.shared.domain.model.MeasurementSystem
 import app.purecipes.shared.domain.model.RecipeFormatHandling
 import app.purecipes.shared.domain.model.RecipeSummary
+import dev.zacsweers.metro.Inject
 
+@Inject
 class FilterRecipesForMeasurementPreferencesUseCase {
 
 	operator fun invoke(

--- a/feature/settings/domain/src/commonMain/kotlin/app/purecipes/feature/measurement/domain/usecase/MeasurementPreferencesUseCases.kt
+++ b/feature/settings/domain/src/commonMain/kotlin/app/purecipes/feature/measurement/domain/usecase/MeasurementPreferencesUseCases.kt
@@ -2,8 +2,10 @@ package app.purecipes.feature.measurement.domain.usecase
 
 import app.purecipes.feature.measurement.domain.repository.MeasurementPreferencesRepository
 import app.purecipes.shared.domain.model.MeasurementPreferences
+import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.Flow
 
+@Inject
 class ObserveMeasurementPreferencesUseCase(
 	private val repository: MeasurementPreferencesRepository,
 ) {
@@ -11,6 +13,7 @@ class ObserveMeasurementPreferencesUseCase(
 	operator fun invoke(): Flow<MeasurementPreferences> = repository.observeMeasurementPreferences()
 }
 
+@Inject
 class GetMeasurementPreferencesUseCase(
 	private val repository: MeasurementPreferencesRepository,
 ) {
@@ -18,6 +21,7 @@ class GetMeasurementPreferencesUseCase(
 	suspend operator fun invoke(): MeasurementPreferences = repository.getMeasurementPreferences()
 }
 
+@Inject
 class SaveMeasurementPreferencesUseCase(
 	private val repository: MeasurementPreferencesRepository,
 ) {
@@ -27,6 +31,7 @@ class SaveMeasurementPreferencesUseCase(
 	}
 }
 
+@Inject
 class ResetMeasurementPreferencesUseCase(
 	private val repository: MeasurementPreferencesRepository,
 ) {
@@ -36,6 +41,7 @@ class ResetMeasurementPreferencesUseCase(
 	}
 }
 
+@Inject
 class MarkMeasurementMismatchSeenUseCase(
 	private val repository: MeasurementPreferencesRepository,
 ) {

--- a/feature/settings/domain/src/commonMain/kotlin/app/purecipes/feature/measurement/domain/usecase/ProcessRecipeDetailsForMeasurementPreferencesUseCase.kt
+++ b/feature/settings/domain/src/commonMain/kotlin/app/purecipes/feature/measurement/domain/usecase/ProcessRecipeDetailsForMeasurementPreferencesUseCase.kt
@@ -6,9 +6,11 @@ import app.purecipes.shared.domain.model.MeasurementPreferences
 import app.purecipes.shared.domain.model.MeasurementSystem
 import app.purecipes.shared.domain.model.RecipeDetails
 import app.purecipes.shared.domain.model.RecipeFormatHandling
+import dev.zacsweers.metro.Inject
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
+@Inject
 class ProcessRecipeDetailsForMeasurementPreferencesUseCase {
 
 	operator fun invoke(

--- a/feature/settings/domain/src/commonMain/kotlin/app/purecipes/feature/settings/domain/usecase/InitializeNotificationsUseCase.kt
+++ b/feature/settings/domain/src/commonMain/kotlin/app/purecipes/feature/settings/domain/usecase/InitializeNotificationsUseCase.kt
@@ -1,7 +1,9 @@
 package app.purecipes.feature.settings.domain.usecase
 
 import app.purecipes.shared.domain.notification.NotificationManager
+import dev.zacsweers.metro.Inject
 
+@Inject
 class InitializeNotificationsUseCase(
 	private val notificationManager: NotificationManager,
 ) {

--- a/feature/settings/domain/src/commonMain/kotlin/app/purecipes/feature/settings/domain/usecase/NotificationPreferencesUseCases.kt
+++ b/feature/settings/domain/src/commonMain/kotlin/app/purecipes/feature/settings/domain/usecase/NotificationPreferencesUseCases.kt
@@ -3,14 +3,17 @@ package app.purecipes.feature.settings.domain.usecase
 import app.purecipes.feature.settings.domain.repository.NotificationPreferencesRepository
 import app.purecipes.shared.domain.model.NotificationPreferences
 import app.purecipes.shared.domain.notification.NotificationManager
+import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.Flow
 
+@Inject
 class ObserveNotificationPreferencesUseCase(
 	private val repository: NotificationPreferencesRepository,
 ) {
 	operator fun invoke(): Flow<NotificationPreferences> = repository.observeNotificationPreferences()
 }
 
+@Inject
 class SaveNotificationPreferencesUseCase(
 	private val repository: NotificationPreferencesRepository,
 	private val notificationManager: NotificationManager,

--- a/feature/settings/domain/src/commonMain/kotlin/app/purecipes/feature/settings/domain/usecase/SendTestNotificationUseCase.kt
+++ b/feature/settings/domain/src/commonMain/kotlin/app/purecipes/feature/settings/domain/usecase/SendTestNotificationUseCase.kt
@@ -2,7 +2,9 @@ package app.purecipes.feature.settings.domain.usecase
 
 import app.purecipes.shared.domain.notification.NotificationData
 import app.purecipes.shared.domain.notification.NotificationManager
+import dev.zacsweers.metro.Inject
 
+@Inject
 class SendTestNotificationUseCase(
 	private val notificationManager: NotificationManager,
 ) {

--- a/feature/sharing/data/src/commonMain/kotlin/app/purecipes/feature/sharing/data/repository/SharingDataModule.kt
+++ b/feature/sharing/data/src/commonMain/kotlin/app/purecipes/feature/sharing/data/repository/SharingDataModule.kt
@@ -8,13 +8,6 @@ import app.purecipes.feature.sharing.domain.repository.CookbookShareRepository
 import app.purecipes.feature.sharing.domain.repository.IncomingLinkRepository
 import app.purecipes.feature.sharing.domain.repository.ShareRepository
 import app.purecipes.feature.sharing.domain.repository.WebLaunchLinkRepository
-import app.purecipes.feature.sharing.domain.usecase.CreateCookbookShareUseCase
-import app.purecipes.feature.sharing.domain.usecase.DeliverIncomingLinkUseCase
-import app.purecipes.feature.sharing.domain.usecase.ImportCookbookShareUseCase
-import app.purecipes.feature.sharing.domain.usecase.ObserveIncomingLinksUseCase
-import app.purecipes.feature.sharing.domain.usecase.PublishWebLaunchLinkUseCase
-import app.purecipes.feature.sharing.domain.usecase.ShareCookbookUseCase
-import app.purecipes.feature.sharing.domain.usecase.ShareRecipeUseCase
 import app.purecipes.shared.data.network.PurecipesApi
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
@@ -41,30 +34,6 @@ interface SharingDataModule {
 	}
 
 	@Provides
-	fun provideDeliverIncomingLinkUseCase(
-		incomingLinkRepository: IncomingLinkRepository,
-	): DeliverIncomingLinkUseCase = DeliverIncomingLinkUseCase(incomingLinkRepository)
-
-	@Provides
-	fun provideObserveIncomingLinksUseCase(
-		incomingLinkRepository: IncomingLinkRepository,
-	): ObserveIncomingLinksUseCase = ObserveIncomingLinksUseCase(incomingLinkRepository)
-
-	@Provides
-	fun providePublishWebLaunchLinkUseCase(
-		webLaunchLinkRepository: WebLaunchLinkRepository,
-		incomingLinkRepository: IncomingLinkRepository,
-	): PublishWebLaunchLinkUseCase = PublishWebLaunchLinkUseCase(
-		webLaunchLinkRepository = webLaunchLinkRepository,
-		incomingLinkRepository = incomingLinkRepository,
-	)
-
-	@Provides
-	fun provideShareRecipeUseCase(shareRepository: ShareRepository): ShareRecipeUseCase {
-		return ShareRecipeUseCase(shareRepository)
-	}
-
-	@Provides
 	fun provideCookbookShareRemoteDataSource(api: PurecipesApi): CookbookShareRemoteDataSource {
 		return CookbookShareRemoteDataSource(api)
 	}
@@ -74,23 +43,5 @@ interface SharingDataModule {
 		remoteDataSource: CookbookShareRemoteDataSource,
 	): CookbookShareRepository {
 		return CookbookShareAccessor(remoteDataSource)
-	}
-
-	@Provides
-	fun provideCreateCookbookShareUseCase(
-		cookbookShareRepository: CookbookShareRepository,
-	): CreateCookbookShareUseCase = CreateCookbookShareUseCase(cookbookShareRepository)
-
-	@Provides
-	fun provideImportCookbookShareUseCase(
-		cookbookShareRepository: CookbookShareRepository,
-	): ImportCookbookShareUseCase = ImportCookbookShareUseCase(cookbookShareRepository)
-
-	@Provides
-	fun provideShareCookbookUseCase(
-		createCookbookShareUseCase: CreateCookbookShareUseCase,
-		shareRepository: ShareRepository,
-	): ShareCookbookUseCase {
-		return ShareCookbookUseCase(createCookbookShareUseCase, shareRepository)
 	}
 }

--- a/feature/sharing/domain/src/commonMain/kotlin/app/purecipes/feature/sharing/domain/usecase/CreateCookbookShareUseCase.kt
+++ b/feature/sharing/domain/src/commonMain/kotlin/app/purecipes/feature/sharing/domain/usecase/CreateCookbookShareUseCase.kt
@@ -3,7 +3,9 @@ package app.purecipes.feature.sharing.domain.usecase
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.sharing.domain.repository.CookbookShareRepository
 import app.purecipes.shared.domain.model.CookbookShareToken
+import dev.zacsweers.metro.Inject
 
+@Inject
 class CreateCookbookShareUseCase(
 	private val cookbookShareRepository: CookbookShareRepository,
 ) {

--- a/feature/sharing/domain/src/commonMain/kotlin/app/purecipes/feature/sharing/domain/usecase/DeliverIncomingLinkUseCase.kt
+++ b/feature/sharing/domain/src/commonMain/kotlin/app/purecipes/feature/sharing/domain/usecase/DeliverIncomingLinkUseCase.kt
@@ -1,7 +1,9 @@
 package app.purecipes.feature.sharing.domain.usecase
 
 import app.purecipes.feature.sharing.domain.repository.IncomingLinkRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class DeliverIncomingLinkUseCase(
 	private val incomingLinkRepository: IncomingLinkRepository,
 ) {

--- a/feature/sharing/domain/src/commonMain/kotlin/app/purecipes/feature/sharing/domain/usecase/ImportCookbookShareUseCase.kt
+++ b/feature/sharing/domain/src/commonMain/kotlin/app/purecipes/feature/sharing/domain/usecase/ImportCookbookShareUseCase.kt
@@ -3,7 +3,9 @@ package app.purecipes.feature.sharing.domain.usecase
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.sharing.domain.repository.CookbookShareRepository
 import app.purecipes.shared.domain.model.CookbookImportResult
+import dev.zacsweers.metro.Inject
 
+@Inject
 class ImportCookbookShareUseCase(
 	private val cookbookShareRepository: CookbookShareRepository,
 ) {

--- a/feature/sharing/domain/src/commonMain/kotlin/app/purecipes/feature/sharing/domain/usecase/ObserveIncomingLinksUseCase.kt
+++ b/feature/sharing/domain/src/commonMain/kotlin/app/purecipes/feature/sharing/domain/usecase/ObserveIncomingLinksUseCase.kt
@@ -2,8 +2,10 @@ package app.purecipes.feature.sharing.domain.usecase
 
 import app.purecipes.feature.sharing.domain.model.PurecipesLink
 import app.purecipes.feature.sharing.domain.repository.IncomingLinkRepository
+import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.Flow
 
+@Inject
 class ObserveIncomingLinksUseCase(
 	private val incomingLinkRepository: IncomingLinkRepository,
 ) {

--- a/feature/sharing/domain/src/commonMain/kotlin/app/purecipes/feature/sharing/domain/usecase/PublishWebLaunchLinkUseCase.kt
+++ b/feature/sharing/domain/src/commonMain/kotlin/app/purecipes/feature/sharing/domain/usecase/PublishWebLaunchLinkUseCase.kt
@@ -2,7 +2,9 @@ package app.purecipes.feature.sharing.domain.usecase
 
 import app.purecipes.feature.sharing.domain.repository.IncomingLinkRepository
 import app.purecipes.feature.sharing.domain.repository.WebLaunchLinkRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class PublishWebLaunchLinkUseCase(
 	private val webLaunchLinkRepository: WebLaunchLinkRepository,
 	private val incomingLinkRepository: IncomingLinkRepository,

--- a/feature/sharing/domain/src/commonMain/kotlin/app/purecipes/feature/sharing/domain/usecase/ShareCookbookUseCase.kt
+++ b/feature/sharing/domain/src/commonMain/kotlin/app/purecipes/feature/sharing/domain/usecase/ShareCookbookUseCase.kt
@@ -3,7 +3,9 @@ package app.purecipes.feature.sharing.domain.usecase
 import app.purecipes.feature.sharing.domain.model.PurecipesLinkUrls
 import app.purecipes.feature.sharing.domain.repository.ShareRepository
 import com.github.michaelbull.result.get
+import dev.zacsweers.metro.Inject
 
+@Inject
 class ShareCookbookUseCase(
 	private val createCookbookShareUseCase: CreateCookbookShareUseCase,
 	private val shareRepository: ShareRepository,

--- a/feature/sharing/domain/src/commonMain/kotlin/app/purecipes/feature/sharing/domain/usecase/ShareRecipeUseCase.kt
+++ b/feature/sharing/domain/src/commonMain/kotlin/app/purecipes/feature/sharing/domain/usecase/ShareRecipeUseCase.kt
@@ -2,7 +2,9 @@ package app.purecipes.feature.sharing.domain.usecase
 
 import app.purecipes.feature.sharing.domain.model.PurecipesLinkUrls
 import app.purecipes.feature.sharing.domain.repository.ShareRepository
+import dev.zacsweers.metro.Inject
 
+@Inject
 class ShareRecipeUseCase(
 	private val shareRepository: ShareRepository,
 ) {


### PR DESCRIPTION
## Summary
- Remove trivial `provideXxxUseCase` factories from feature `*DataModule` files and wire use cases via Metro `@Inject` constructor injection.
- Enable Metro on `convention.domain` so domain use cases participate in the graph.

Closes #125

## Test plan
- [x] `./gradlew detektAll`
- [x] All eight `*:data:jvmTest` tasks
- [x] `:app:assembleDebug`
- [x] `:umbrella:compileKotlinIosArm64`
- [x] `:umbrella:compileKotlinWasmJs`