### PR TITLE
132 Move post-login navigation into shared module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,11 @@ See the **Compose UI file layout** bullet under [Core Principles](#core-principl
 If this MCP server is not available, stop all work and notify the user.
 If possible find a way to restart in the same request, for example by using ask question tool.
 
+## Rule: GitHub operations (user-github MCP server)
+
+For issues, pull requests, checks, releases, and other GitHub tasks, use the **user-github** MCP server tools. Do **not** use the GitHub CLI (`gh`).
+If this MCP server is not available, stop and notify the user instead of falling back to `gh`.
+
 ## Rule: Use kotlin-result library
 
 Do not use try/catch structure for network calls or similar. Use the Outcome class instead, which is a type alias 

--- a/feature/main/src/commonMain/kotlin/app/purecipes/feature/main/ui/MainScreen.kt
+++ b/feature/main/src/commonMain/kotlin/app/purecipes/feature/main/ui/MainScreen.kt
@@ -26,6 +26,7 @@ import app.purecipes.feature.recipedetails.ui.navigation.installRecipeDetailsFlo
 import app.purecipes.feature.search.ui.navigation.installSearchFlow
 import app.purecipes.feature.settings.ui.navigation.installSettingsFlow
 import app.purecipes.shared.ui.component.HandleSystemBack
+import app.purecipes.shared.ui.navigation.PostLoginAction
 import app.purecipes.shared.ui.theme.PurecipesTheme
 import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
 import dev.zacsweers.metrox.viewmodel.MetroViewModelFactory
@@ -113,9 +114,7 @@ private fun MainScreenContent(
 							sessionKey = sessionKey,
 							onRecipeSelect = viewModel::onRecipeSelected,
 							onRequestLogInForFilters = {
-								viewModel.requestLoginForPostLoginAction(
-									PostLoginNavOrigin.RECIPE_SEARCH_FILTERS,
-								)
+								viewModel.requestLoginForPostLoginAction(PostLoginAction.OpenSearchFilters)
 							},
 						)
 						installRecipeDetailsFlow(

--- a/feature/main/src/commonMain/kotlin/app/purecipes/feature/main/ui/MainViewModel.kt
+++ b/feature/main/src/commonMain/kotlin/app/purecipes/feature/main/ui/MainViewModel.kt
@@ -28,6 +28,9 @@ import app.purecipes.feature.sharing.domain.usecase.ObserveIncomingLinksUseCase
 import app.purecipes.feature.sharing.domain.usecase.PublishWebLaunchLinkUseCase
 import app.purecipes.shared.data.config.PurecipesConfig
 import app.purecipes.shared.ui.navigation.Navigator
+import app.purecipes.shared.ui.navigation.PostLoginAction
+import app.purecipes.shared.ui.navigation.PostLoginNavigationTarget
+import app.purecipes.shared.ui.navigation.resolvePostLoginNavigationTarget
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
@@ -51,8 +54,7 @@ class MainViewModel(
 
 	private var backStack: NavBackStack<NavKey> = NavBackStack(SearchDestination())
 
-	private var pendingPostLoginOrigin: PostLoginNavOrigin? = null
-	private var stagedCookbookShareToken: String? = null
+	private var pendingPostLoginAction: PostLoginAction? = null
 
 	private var previousAuthenticationState: AuthenticationState? = null
 	private var previousSessionKey: String? = null
@@ -117,12 +119,11 @@ class MainViewModel(
 	}
 
 	fun clearPostLoginNavigationState() {
-		pendingPostLoginOrigin = null
-		stagedCookbookShareToken = null
+		pendingPostLoginAction = null
 	}
 
-	internal fun requestLoginForPostLoginAction(origin: PostLoginNavOrigin) {
-		pendingPostLoginOrigin = origin
+	internal fun requestLoginForPostLoginAction(action: PostLoginAction) {
+		pendingPostLoginAction = action
 		onTabSelected(mainTabs.first { it.destination == AccountDestination })
 	}
 
@@ -140,10 +141,10 @@ class MainViewModel(
 		return stack
 	}
 
-	internal fun takePostLoginOriginAfterSignIn(): PostLoginNavOrigin? {
-		val origin = pendingPostLoginOrigin
-		pendingPostLoginOrigin = null
-		return origin
+	internal fun takePendingPostLoginAction(): PostLoginAction? {
+		val action = pendingPostLoginAction
+		pendingPostLoginAction = null
+		return action
 	}
 
 	fun shouldExit(): Boolean = backStack.size == 1 && backStack.firstOrNull() is SearchDestination
@@ -152,7 +153,7 @@ class MainViewModel(
 
 	internal fun onTabSelected(tab: MainTab) {
 		if (tab.destination !is AccountDestination) {
-			pendingPostLoginOrigin = null
+			pendingPostLoginAction = null
 		}
 		val root = tabRootDestination(tab)
 		if (backStack.size != 1 || !backStack.firstOrNull().isSameTabRoot(root)) {
@@ -171,12 +172,7 @@ class MainViewModel(
 		}
 	}
 
-	fun stageCookbookShareImport(token: String) {
-		stagedCookbookShareToken = token
-	}
-
 	private fun navigateToRecipe(recipeId: Int) {
-		stagedCookbookShareToken = null
 		if (backStack.firstOrNull() !is SearchDestination) {
 			backStack.clear()
 			backStack += SearchDestination()
@@ -191,7 +187,6 @@ class MainViewModel(
 	}
 
 	private fun navigateToCookbookShare(token: String) {
-		stagedCookbookShareToken = null
 		navigator.replaceTabRoot(FavoritesDestination(cookbookShareToken = token))
 	}
 
@@ -259,15 +254,7 @@ class MainViewModel(
 			clearPostLoginNavigationState()
 		} else if (previous is AuthenticationState.SignedOut && state is AuthenticationState.SignedIn) {
 			onAuthenticationSucceeded()
-			when (takePostLoginOriginAfterSignIn()) {
-				PostLoginNavOrigin.RECIPE_SEARCH_FILTERS ->
-					navigator.replaceTabRoot(SearchDestination(openFiltersOnStart = true))
-
-				PostLoginNavOrigin.COOKBOOK_SHARE_IMPORT ->
-					onTabSelected(mainTabs.first { it.destination is FavoritesDestination })
-
-				null -> Unit
-			}
+			takePendingPostLoginAction()?.let(::applyPostLoginNavigation)
 		}
 	}
 
@@ -287,8 +274,7 @@ class MainViewModel(
 		incomingLinksCollectionJob = viewModelScope.launch {
 			observeIncomingLinks().collect { link ->
 				if (link is PurecipesLink.CookbookShare && !isSignedIn) {
-					stageCookbookShareImport(link.token)
-					requestLoginForPostLoginAction(PostLoginNavOrigin.COOKBOOK_SHARE_IMPORT)
+					requestLoginForPostLoginAction(PostLoginAction.ImportCookbookShare(link.token))
 				} else {
 					onDeepLink(link)
 				}
@@ -296,16 +282,20 @@ class MainViewModel(
 		}
 	}
 
-	private fun tabRootDestination(tab: MainTab): NavKey = when (tab.destination) {
-		is SearchDestination -> SearchDestination()
-		is FavoritesDestination -> FavoritesDestination(cookbookShareToken = consumeStagedCookbookShareToken())
-		else -> tab.destination
+	private fun applyPostLoginNavigation(action: PostLoginAction) {
+		when (val target = resolvePostLoginNavigationTarget(action)) {
+			PostLoginNavigationTarget.OpenSearchWithFilters ->
+				navigator.replaceTabRoot(SearchDestination(openFiltersOnStart = true))
+
+			is PostLoginNavigationTarget.OpenFavoritesWithCookbookShare ->
+				navigator.replaceTabRoot(FavoritesDestination(cookbookShareToken = target.token))
+		}
 	}
 
-	private fun consumeStagedCookbookShareToken(): String? {
-		val token = stagedCookbookShareToken
-		stagedCookbookShareToken = null
-		return token
+	private fun tabRootDestination(tab: MainTab): NavKey = when (tab.destination) {
+		is SearchDestination -> SearchDestination()
+		is FavoritesDestination -> FavoritesDestination()
+		else -> tab.destination
 	}
 
 	private fun NavKey?.isSameTabRoot(root: NavKey): Boolean = when (root) {

--- a/feature/main/src/commonMain/kotlin/app/purecipes/feature/main/ui/PostLoginNavOrigin.kt
+++ b/feature/main/src/commonMain/kotlin/app/purecipes/feature/main/ui/PostLoginNavOrigin.kt
@@ -1,6 +1,0 @@
-package app.purecipes.feature.main.ui
-
-internal enum class PostLoginNavOrigin {
-	RECIPE_SEARCH_FILTERS,
-	COOKBOOK_SHARE_IMPORT,
-}

--- a/feature/main/src/commonTest/kotlin/app/purecipes/feature/main/ui/MainViewModelStartTest.kt
+++ b/feature/main/src/commonTest/kotlin/app/purecipes/feature/main/ui/MainViewModelStartTest.kt
@@ -15,6 +15,7 @@ import app.purecipes.shared.testfixtures.fake.FakeAuthenticationRepository
 import app.purecipes.shared.testfixtures.fake.FakeConsentRepository
 import app.purecipes.shared.testfixtures.fake.fakeAuthUser
 import app.purecipes.shared.testfixtures.runUnconfinedViewModelTest
+import app.purecipes.shared.ui.navigation.PostLoginAction
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -46,7 +47,7 @@ class MainViewModelStartTest {
 		val viewModel = mainViewModelForTest(
 			authenticationRepository = authenticationRepository,
 		)
-		viewModel.requestLoginForPostLoginAction(PostLoginNavOrigin.RECIPE_SEARCH_FILTERS)
+		viewModel.requestLoginForPostLoginAction(PostLoginAction.OpenSearchFilters)
 		viewModel.onOpenEmailSignIn(prefilledEmail = sampleUser.email)
 		viewModel.start()
 		authenticationRepository.signInWithGoogle(
@@ -68,8 +69,7 @@ class MainViewModelStartTest {
 		val viewModel = mainViewModelForTest(
 			authenticationRepository = authenticationRepository,
 		)
-		viewModel.requestLoginForPostLoginAction(PostLoginNavOrigin.COOKBOOK_SHARE_IMPORT)
-		viewModel.stageCookbookShareImport(sampleShareToken)
+		viewModel.requestLoginForPostLoginAction(PostLoginAction.ImportCookbookShare(sampleShareToken))
 		viewModel.start()
 		authenticationRepository.signInWithGoogle(
 			GoogleAuthenticationProfile(
@@ -172,7 +172,7 @@ class MainViewModelStartTest {
 		val viewModel = mainViewModelForTest(
 			authenticationRepository = authenticationRepository,
 		)
-		viewModel.requestLoginForPostLoginAction(PostLoginNavOrigin.RECIPE_SEARCH_FILTERS)
+		viewModel.requestLoginForPostLoginAction(PostLoginAction.OpenSearchFilters)
 		viewModel.start()
 		authenticationRepository.signInWithGoogle(
 			GoogleAuthenticationProfile(
@@ -186,7 +186,7 @@ class MainViewModelStartTest {
 
 		authenticationRepository.signOut()
 
-		viewModel.takePostLoginOriginAfterSignIn() shouldBe null
+		viewModel.takePendingPostLoginAction() shouldBe null
 	}
 }
 

--- a/feature/main/src/commonTest/kotlin/app/purecipes/feature/main/ui/MainViewModelTest.kt
+++ b/feature/main/src/commonTest/kotlin/app/purecipes/feature/main/ui/MainViewModelTest.kt
@@ -7,6 +7,7 @@ import app.purecipes.feature.recipedetails.ui.navigation.RecipeDetailsDestinatio
 import app.purecipes.feature.search.ui.navigation.SearchDestination
 import app.purecipes.feature.settings.ui.navigation.AccountSettingsDestination
 import app.purecipes.feature.sharing.domain.model.PurecipesLink
+import app.purecipes.shared.ui.navigation.PostLoginAction
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
 
@@ -25,10 +26,10 @@ class MainViewModelTest {
 	@Test
 	fun `requestLoginForPostLoginAction navigates to account and preserves origin until sign in`() {
 		val viewModel = mainViewModelForTest()
-		viewModel.requestLoginForPostLoginAction(PostLoginNavOrigin.RECIPE_SEARCH_FILTERS)
+		viewModel.requestLoginForPostLoginAction(PostLoginAction.OpenSearchFilters)
 
 		viewModel.peekBackStack() shouldBe listOf<NavKey>(AccountDestination)
-		viewModel.takePostLoginOriginAfterSignIn() shouldBe PostLoginNavOrigin.RECIPE_SEARCH_FILTERS
+		viewModel.takePendingPostLoginAction() shouldBe PostLoginAction.OpenSearchFilters
 	}
 
 	@Test
@@ -39,7 +40,7 @@ class MainViewModelTest {
 		viewModel.onTabSelected(mainTabs.first { it.destination is SearchDestination })
 
 		viewModel.peekBackStack() shouldBe listOf<NavKey>(SearchDestination())
-		viewModel.takePostLoginOriginAfterSignIn() shouldBe null
+		viewModel.takePendingPostLoginAction() shouldBe null
 	}
 
 	@Test
@@ -90,16 +91,13 @@ class MainViewModelTest {
 	}
 
 	@Test
-	fun `stage cookbook share import stores token until favorites tab is selected`() {
+	fun `requestLoginForPostLoginAction preserves cookbook share token until sign in`() {
 		val viewModel = mainViewModelForTest()
-		viewModel.stageCookbookShareImport(sampleShareToken)
+		viewModel.requestLoginForPostLoginAction(PostLoginAction.ImportCookbookShare(sampleShareToken))
 
-		viewModel.peekBackStack() shouldBe listOf<NavKey>(SearchDestination())
-		viewModel.onTabSelected(mainTabs.first { it.destination is FavoritesDestination })
-
-		viewModel.peekBackStack() shouldBe listOf<NavKey>(
-			FavoritesDestination(cookbookShareToken = sampleShareToken),
-		)
+		viewModel.peekBackStack() shouldBe listOf<NavKey>(AccountDestination)
+		viewModel.takePendingPostLoginAction() shouldBe
+			PostLoginAction.ImportCookbookShare(sampleShareToken)
 	}
 
 	@Test

--- a/shared/ui/build.gradle.kts
+++ b/shared/ui/build.gradle.kts
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 plugins {
 	id("convention.kmp")
 	id("convention.compose")
+	id("convention.common-test")
 }
 
 kotlin {

--- a/shared/ui/src/commonMain/kotlin/app/purecipes/shared/ui/navigation/PostLoginAction.kt
+++ b/shared/ui/src/commonMain/kotlin/app/purecipes/shared/ui/navigation/PostLoginAction.kt
@@ -1,0 +1,7 @@
+package app.purecipes.shared.ui.navigation
+
+sealed interface PostLoginAction {
+	data object OpenSearchFilters : PostLoginAction
+
+	data class ImportCookbookShare(val token: String) : PostLoginAction
+}

--- a/shared/ui/src/commonMain/kotlin/app/purecipes/shared/ui/navigation/PostLoginNavigationTarget.kt
+++ b/shared/ui/src/commonMain/kotlin/app/purecipes/shared/ui/navigation/PostLoginNavigationTarget.kt
@@ -1,0 +1,14 @@
+package app.purecipes.shared.ui.navigation
+
+sealed interface PostLoginNavigationTarget {
+	data object OpenSearchWithFilters : PostLoginNavigationTarget
+
+	data class OpenFavoritesWithCookbookShare(val token: String) : PostLoginNavigationTarget
+}
+
+fun resolvePostLoginNavigationTarget(action: PostLoginAction): PostLoginNavigationTarget =
+	when (action) {
+		PostLoginAction.OpenSearchFilters -> PostLoginNavigationTarget.OpenSearchWithFilters
+		is PostLoginAction.ImportCookbookShare ->
+			PostLoginNavigationTarget.OpenFavoritesWithCookbookShare(action.token)
+	}

--- a/shared/ui/src/commonTest/kotlin/app/purecipes/shared/ui/navigation/PostLoginNavigationTargetTest.kt
+++ b/shared/ui/src/commonTest/kotlin/app/purecipes/shared/ui/navigation/PostLoginNavigationTargetTest.kt
@@ -1,0 +1,21 @@
+package app.purecipes.shared.ui.navigation
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class PostLoginNavigationTargetTest {
+
+	private val sampleShareToken = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+	@Test
+	fun `open search filters resolves to search with filters target`() {
+		resolvePostLoginNavigationTarget(PostLoginAction.OpenSearchFilters) shouldBe
+			PostLoginNavigationTarget.OpenSearchWithFilters
+	}
+
+	@Test
+	fun `import cookbook share resolves to favorites with token`() {
+		resolvePostLoginNavigationTarget(PostLoginAction.ImportCookbookShare(sampleShareToken)) shouldBe
+			PostLoginNavigationTarget.OpenFavoritesWithCookbookShare(sampleShareToken)
+	}
+}


### PR DESCRIPTION
## Summary

- Moves post-login intents from `feature:main` into `:shared:ui` as `PostLoginAction` and `PostLoginNavigationTarget`, with `resolvePostLoginNavigationTarget()` for testable routing logic.
- Consolidates pending post-login state into a single `PostLoginAction?` (removes `PostLoginNavOrigin` and separate cookbook share token staging).
- `MainViewModel` applies resolved targets to `NavKey`s via a thin adapter after sign-in.

Closes #132

## Test plan

- [x] `./gradlew detektAll`
- [x] `./gradlew :shared:ui:jvmTest`
- [x] `./gradlew :feature:main:jvmTest`