### PR TITLE
131: Replace favorites refresh signal with domain event stream

### DIFF
--- a/config/detekt/formatting-detekt-config.yml
+++ b/config/detekt/formatting-detekt-config.yml
@@ -158,7 +158,7 @@ formatting:
     active: true
     autoCorrect: true
   NoUnusedImports:
-    active: true
+    active: false
     autoCorrect: true
   NoWildcardImports:
     active: true

--- a/feature/favorites/data/src/commonMain/kotlin/app/purecipes/feature/favorites/data/repository/FavoritesAccessor.kt
+++ b/feature/favorites/data/src/commonMain/kotlin/app/purecipes/feature/favorites/data/repository/FavoritesAccessor.kt
@@ -1,16 +1,35 @@
 package app.purecipes.feature.favorites.data.repository
 
 import app.purecipes.feature.favorites.data.datasource.FavoritesDataSource
+import app.purecipes.feature.favorites.domain.model.FavoriteEvent
 import app.purecipes.feature.favorites.domain.repository.FavoritesRepository
+import com.github.michaelbull.result.getError
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 
 class FavoritesAccessor(
 	private val remoteDataSource: FavoritesDataSource.Remote,
 ) : FavoritesRepository {
 
-	override suspend fun addFavorite(recipeId: Int) = remoteDataSource.addFavorite(recipeId)
+	private val favoriteEvents = MutableSharedFlow<FavoriteEvent>(extraBufferCapacity = 1)
+
+	override suspend fun addFavorite(recipeId: Int) =
+		remoteDataSource.addFavorite(recipeId).also { outcome ->
+			if (outcome.getError() == null) {
+				favoriteEvents.tryEmit(FavoriteEvent.Added(recipeId))
+			}
+		}
 
 	override suspend fun getFavoriteRecipesPage(pageNumber: Int, pageSize: Int) =
 		remoteDataSource.getFavoriteRecipesPage(pageNumber, pageSize)
 
-	override suspend fun removeFavorite(recipeId: Int) = remoteDataSource.removeFavorite(recipeId)
+	override suspend fun removeFavorite(recipeId: Int) =
+		remoteDataSource.removeFavorite(recipeId).also { outcome ->
+			if (outcome.getError() == null) {
+				favoriteEvents.tryEmit(FavoriteEvent.Removed(recipeId))
+			}
+		}
+
+	override fun observeFavoriteEvents(): Flow<FavoriteEvent> = favoriteEvents.asSharedFlow()
 }

--- a/feature/favorites/data/src/commonTest/kotlin/app/purecipes/feature/favorites/data/repository/FavoritesAccessorTest.kt
+++ b/feature/favorites/data/src/commonTest/kotlin/app/purecipes/feature/favorites/data/repository/FavoritesAccessorTest.kt
@@ -1,15 +1,22 @@
 package app.purecipes.feature.favorites.data.repository
 
 import app.purecipes.feature.favorites.data.datasource.FavoritesRemoteDataSource
+import app.purecipes.feature.favorites.domain.model.FavoriteEvent
 import app.purecipes.shared.datatestfixtures.fake.FakePurecipesApi
 import app.purecipes.shared.domain.model.Cuisine
 import app.purecipes.shared.domain.model.RecipeSummary
 import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class FavoritesAccessorTest {
 
 	@Test
@@ -33,5 +40,18 @@ class FavoritesAccessorTest {
 		outcome.get()?.items shouldBe expected
 		outcome.get()?.totalMatches shouldBe 1
 		outcome.getError() shouldBe null
+	}
+
+	@Test
+	fun `add favorite emits added event`() = runTest {
+		val accessor = FavoritesAccessor(
+			FavoritesRemoteDataSource(FakePurecipesApi()),
+		)
+		val event = async { accessor.observeFavoriteEvents().take(1).single() }
+		runCurrent()
+
+		accessor.addFavorite(recipeId = 42)
+
+		event.await() shouldBe FavoriteEvent.Added(recipeId = 42)
 	}
 }

--- a/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/model/FavoriteEvent.kt
+++ b/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/model/FavoriteEvent.kt
@@ -1,0 +1,10 @@
+package app.purecipes.feature.favorites.domain.model
+
+sealed interface FavoriteEvent {
+
+	val recipeId: Int
+
+	data class Added(override val recipeId: Int) : FavoriteEvent
+
+	data class Removed(override val recipeId: Int) : FavoriteEvent
+}

--- a/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/repository/FavoritesRepository.kt
+++ b/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/repository/FavoritesRepository.kt
@@ -1,7 +1,9 @@
 package app.purecipes.feature.favorites.domain.repository
 
 import app.purecipes.base.kotlin.result.Outcome
+import app.purecipes.feature.favorites.domain.model.FavoriteEvent
 import app.purecipes.shared.domain.model.SearchResultsPage
+import kotlinx.coroutines.flow.Flow
 
 interface FavoritesRepository {
 
@@ -10,4 +12,6 @@ interface FavoritesRepository {
 	suspend fun getFavoriteRecipesPage(pageNumber: Int, pageSize: Int): Outcome<SearchResultsPage>
 
 	suspend fun removeFavorite(recipeId: Int): Outcome<Unit>
+
+	fun observeFavoriteEvents(): Flow<FavoriteEvent>
 }

--- a/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/ObserveFavoriteEventsUseCase.kt
+++ b/feature/favorites/domain/src/commonMain/kotlin/app/purecipes/feature/favorites/domain/usecase/ObserveFavoriteEventsUseCase.kt
@@ -1,0 +1,14 @@
+package app.purecipes.feature.favorites.domain.usecase
+
+import app.purecipes.feature.favorites.domain.model.FavoriteEvent
+import app.purecipes.feature.favorites.domain.repository.FavoritesRepository
+import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.flow.Flow
+
+@Inject
+class ObserveFavoriteEventsUseCase(
+	private val repository: FavoritesRepository,
+) {
+
+	operator fun invoke(): Flow<FavoriteEvent> = repository.observeFavoriteEvents()
+}

--- a/feature/favorites/domain/src/commonTest/kotlin/app/purecipes/feature/favorites/domain/usecase/ObserveFavoriteEventsUseCaseTest.kt
+++ b/feature/favorites/domain/src/commonTest/kotlin/app/purecipes/feature/favorites/domain/usecase/ObserveFavoriteEventsUseCaseTest.kt
@@ -1,0 +1,40 @@
+package app.purecipes.feature.favorites.domain.usecase
+
+import app.purecipes.feature.favorites.domain.model.FavoriteEvent
+import app.purecipes.shared.testfixtures.fake.FakeFavoritesRepository
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ObserveFavoriteEventsUseCaseTest {
+
+	@Test
+	fun `add favorite emits added event`() = runTest {
+		val repository = FakeFavoritesRepository()
+		val useCase = ObserveFavoriteEventsUseCase(repository)
+		val event = async { useCase().take(1).single() }
+		runCurrent()
+
+		repository.addFavorite(recipeId = 42)
+
+		event.await() shouldBe FavoriteEvent.Added(recipeId = 42)
+	}
+
+	@Test
+	fun `remove favorite emits removed event`() = runTest {
+		val repository = FakeFavoritesRepository()
+		val useCase = ObserveFavoriteEventsUseCase(repository)
+		val event = async { useCase().take(1).single() }
+		runCurrent()
+
+		repository.removeFavorite(recipeId = 7)
+
+		event.await() shouldBe FavoriteEvent.Removed(recipeId = 7)
+	}
+}

--- a/feature/favorites/ui/src/androidDeviceTest/kotlin/app/purecipes/feature/favorites/ui/FavoritesScreenTest.kt
+++ b/feature/favorites/ui/src/androidDeviceTest/kotlin/app/purecipes/feature/favorites/ui/FavoritesScreenTest.kt
@@ -1,6 +1,5 @@
 package app.purecipes.feature.favorites.ui
 
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
@@ -13,6 +12,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.purecipes.base.kotlin.result.Outcome
+import app.purecipes.feature.favorites.domain.model.FavoriteEvent
 import app.purecipes.feature.favorites.domain.repository.CookbookCoverRepository
 import app.purecipes.feature.favorites.domain.repository.CookbooksRepository
 import app.purecipes.feature.favorites.domain.usecase.CreateCookbookUseCase
@@ -21,6 +21,7 @@ import app.purecipes.feature.favorites.domain.usecase.GetCookbookCoverImageUrlUs
 import app.purecipes.feature.favorites.domain.usecase.GetCookbookRecipesPageUseCase
 import app.purecipes.feature.favorites.domain.usecase.GetCookbooksPageUseCase
 import app.purecipes.feature.favorites.domain.usecase.GetFavoriteRecipesPageUseCase
+import app.purecipes.feature.favorites.domain.usecase.ObserveFavoriteEventsUseCase
 import app.purecipes.shared.domain.model.CookbookListPage
 import app.purecipes.shared.domain.model.CookbookRef
 import app.purecipes.shared.domain.model.CookbookSummary
@@ -47,7 +48,6 @@ class FavoritesScreenTest {
 		setTrackedContent {
 			PurecipesTheme {
 				FavoritesScreen(
-					refreshSignal = REFRESH_SIGNAL,
 					sessionKey = "session",
 					viewModel = favoritesViewModelForTest(),
 					onRecipeSelect = {},
@@ -80,7 +80,6 @@ class FavoritesScreenTest {
 		setTrackedContent {
 			PurecipesTheme {
 				FavoritesScreen(
-					refreshSignal = REFRESH_SIGNAL,
 					sessionKey = "session",
 					viewModel = favoritesViewModelForTest(cookbooksRepository = cookbooksRepo),
 					onRecipeSelect = {},
@@ -98,7 +97,6 @@ class FavoritesScreenTest {
 		setTrackedContent {
 			PurecipesTheme {
 				FavoritesScreen(
-					refreshSignal = REFRESH_SIGNAL,
 					sessionKey = "session",
 					viewModel = favoritesViewModelForTest(cookbooksRepository = cookbooksRepo),
 					onRecipeSelect = {},
@@ -137,7 +135,6 @@ class FavoritesScreenTest {
 		setTrackedContent {
 			PurecipesTheme {
 				FavoritesScreen(
-					refreshSignal = REFRESH_SIGNAL,
 					sessionKey = "session",
 					viewModel = favoritesViewModelForTest(cookbooksRepository = cookbooksRepo),
 					onRecipeSelect = {},
@@ -161,15 +158,17 @@ class FavoritesScreenTest {
 	}
 
 	@Test
-	fun cookbookDetailRefreshRemovesRecipeAfterFavoritesRefreshSignal() = runRecompositionTrackingUiTest {
+	fun cookbookDetailRefreshRemovesRecipeAfterFavoriteEvent() = runRecompositionTrackingUiTest {
 		val cookbooksRepo = MutableCookbooksRepository()
-		val refreshSignalState = mutableIntStateOf(REFRESH_SIGNAL)
+		val favoritesRepo = FakeFavoritesRepository()
 		setTrackedContent {
 			PurecipesTheme {
 				FavoritesScreen(
-					refreshSignal = refreshSignalState.intValue,
 					sessionKey = "session",
-					viewModel = favoritesViewModelForTest(cookbooksRepository = cookbooksRepo),
+					viewModel = favoritesViewModelForTest(
+						favoritesRepository = favoritesRepo,
+						cookbooksRepository = cookbooksRepo,
+					),
 					onRecipeSelect = {},
 				)
 			}
@@ -182,18 +181,17 @@ class FavoritesScreenTest {
 
 		runOnIdle {
 			cookbooksRepo.setCookbookRecipes(emptyList())
-			refreshSignalState.intValue += 1
+			favoritesRepo.emitFavoriteEvent(FavoriteEvent.Removed(recipeId = TEST_RECIPE_ID))
 		}
 
-		waitForIdle()
-		onNodeWithText("Cookbooks").performClick()
-		onNodeWithText(TEST_COOKBOOK_NAME).performClick()
-		onAllNodesWithText(TEST_RECIPE_TITLE).assertCountEquals(0)
+		waitUntil(timeoutMillis = 5_000) {
+			onAllNodesWithText(TEST_RECIPE_TITLE).fetchSemanticsNodes().isEmpty()
+		}
+		onNodeWithText("0 recipes").assertIsDisplayed()
 	}
 
 	private companion object {
 
-		const val REFRESH_SIGNAL = 1
 		const val NON_EMPTY_COOKBOOK_ID = 21
 		const val EMPTY_COOKBOOK_ID = 22
 		const val TEST_COOKBOOK_ID = 23
@@ -287,6 +285,7 @@ private fun favoritesViewModelForTest(
 	getCookbookRecipesPage = GetCookbookRecipesPageUseCase(cookbooksRepository),
 	getCookbookCoverImageUrl = testCookbookCoverImageUrl,
 	importCookbookShare = unusedImportCookbookShareUseCase(),
+	observeFavoriteEvents = ObserveFavoriteEventsUseCase(favoritesRepository),
 	shareCookbook = unusedShareCookbookUseCase(),
 	sessionKey = sessionKey,
 )

--- a/feature/favorites/ui/src/androidDeviceTest/kotlin/app/purecipes/feature/favorites/ui/FavoritesScreenTest.kt
+++ b/feature/favorites/ui/src/androidDeviceTest/kotlin/app/purecipes/feature/favorites/ui/FavoritesScreenTest.kt
@@ -1,7 +1,6 @@
 package app.purecipes.feature.favorites.ui
 
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.onAllNodesWithTag

--- a/feature/favorites/ui/src/commonMain/kotlin/app/purecipes/feature/favorites/ui/FavoritesScreen.kt
+++ b/feature/favorites/ui/src/commonMain/kotlin/app/purecipes/feature/favorites/ui/FavoritesScreen.kt
@@ -71,7 +71,6 @@ internal const val CREATE_COOKBOOK_DIALOG_INPUT_TAG = "createCookbookDialogInput
 
 @Composable
 fun FavoritesScreen(
-	refreshSignal: Int,
 	modifier: Modifier = Modifier,
 	sessionKey: String? = null,
 	initialCookbookShareToken: String? = null,
@@ -84,7 +83,7 @@ fun FavoritesScreen(
 	var showCreateCookbookDialog by remember { mutableStateOf(false) }
 	var pendingDeleteCookbook by remember { mutableStateOf<CookbookSummary?>(null) }
 
-	LaunchedEffect(refreshSignal, sessionKey) {
+	LaunchedEffect(sessionKey) {
 		if (sessionKey != null) {
 			viewModel.loadFavorites()
 		}

--- a/feature/favorites/ui/src/commonMain/kotlin/app/purecipes/feature/favorites/ui/FavoritesViewModel.kt
+++ b/feature/favorites/ui/src/commonMain/kotlin/app/purecipes/feature/favorites/ui/FavoritesViewModel.kt
@@ -14,6 +14,7 @@ import app.purecipes.feature.favorites.domain.usecase.GetCookbookCoverImageUrlUs
 import app.purecipes.feature.favorites.domain.usecase.GetCookbookRecipesPageUseCase
 import app.purecipes.feature.favorites.domain.usecase.GetCookbooksPageUseCase
 import app.purecipes.feature.favorites.domain.usecase.GetFavoriteRecipesPageUseCase
+import app.purecipes.feature.favorites.domain.usecase.ObserveFavoriteEventsUseCase
 import app.purecipes.feature.sharing.domain.usecase.ImportCookbookShareUseCase
 import app.purecipes.feature.sharing.domain.usecase.ShareCookbookUseCase
 import app.purecipes.shared.domain.model.CookbookSummary
@@ -53,8 +54,19 @@ class FavoritesViewModel(
 	private val getCookbookCoverImageUrl: GetCookbookCoverImageUrlUseCase,
 	private val importCookbookShare: ImportCookbookShareUseCase,
 	private val shareCookbook: ShareCookbookUseCase,
+	private val observeFavoriteEvents: ObserveFavoriteEventsUseCase,
 	@Assisted private val sessionKey: String?,
 ) : ViewModel() {
+
+	init {
+		if (sessionKey != null) {
+			viewModelScope.launch {
+				observeFavoriteEvents().collect {
+					loadFavorites()
+				}
+			}
+		}
+	}
 
 	var selectedTab by mutableStateOf(FavoritesTab.SavedRecipes)
 		private set

--- a/feature/favorites/ui/src/commonMain/kotlin/app/purecipes/feature/favorites/ui/navigation/FavoritesNavigation.kt
+++ b/feature/favorites/ui/src/commonMain/kotlin/app/purecipes/feature/favorites/ui/navigation/FavoritesNavigation.kt
@@ -10,13 +10,11 @@ import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
 
 fun EntryProviderScope<NavKey>.installFavoritesFlow(
-	refreshSignal: Int,
 	sessionKey: String?,
 	onRecipeSelect: (Int) -> Unit,
 ) {
 	entry<FavoritesDestination> { destination ->
 		FavoritesScreen(
-			refreshSignal = refreshSignal,
 			modifier = Modifier.fillMaxSize(),
 			sessionKey = sessionKey,
 			initialCookbookShareToken = destination.cookbookShareToken,

--- a/feature/favorites/ui/src/commonTest/kotlin/app/purecipes/feature/favorites/ui/FavoritesViewModelTest.kt
+++ b/feature/favorites/ui/src/commonTest/kotlin/app/purecipes/feature/favorites/ui/FavoritesViewModelTest.kt
@@ -1,6 +1,7 @@
 package app.purecipes.feature.favorites.ui
 
 import app.purecipes.base.kotlin.result.Failure
+import app.purecipes.feature.favorites.domain.model.FavoriteEvent
 import app.purecipes.feature.favorites.domain.repository.CookbookCoverRepository
 import app.purecipes.feature.favorites.domain.usecase.CreateCookbookUseCase
 import app.purecipes.feature.favorites.domain.usecase.DeleteCookbookUseCase
@@ -8,6 +9,7 @@ import app.purecipes.feature.favorites.domain.usecase.GetCookbookCoverImageUrlUs
 import app.purecipes.feature.favorites.domain.usecase.GetCookbookRecipesPageUseCase
 import app.purecipes.feature.favorites.domain.usecase.GetCookbooksPageUseCase
 import app.purecipes.feature.favorites.domain.usecase.GetFavoriteRecipesPageUseCase
+import app.purecipes.feature.favorites.domain.usecase.ObserveFavoriteEventsUseCase
 import app.purecipes.shared.domain.model.CookbookListPage
 import app.purecipes.shared.domain.model.CookbookSummary
 import app.purecipes.shared.domain.model.Cuisine
@@ -68,6 +70,7 @@ class FavoritesViewModelTest {
 			getCookbookRecipesPage = GetCookbookRecipesPageUseCase(FakeCookbooksRepository()),
 			getCookbookCoverImageUrl = getCookbookCoverImageUrl,
 			importCookbookShare = unusedImportCookbookShareUseCase(),
+			observeFavoriteEvents = ObserveFavoriteEventsUseCase(favoritesRepo),
 			shareCookbook = unusedShareCookbookUseCase(),
 			sessionKey = "session",
 		)
@@ -81,18 +84,18 @@ class FavoritesViewModelTest {
 
 	@Test
 	fun `load favorites exposes error`() = runViewModelTest {
+		val favoritesRepo = FakeFavoritesRepository(
+			getFavoriteRecipesPageResult = Err(Failure.ServerError("Favorites failed")),
+		)
 		val viewModel = FavoritesViewModel(
-			getFavoriteRecipesPage = GetFavoriteRecipesPageUseCase(
-				FakeFavoritesRepository(
-					getFavoriteRecipesPageResult = Err(Failure.ServerError("Favorites failed")),
-				),
-			),
+			getFavoriteRecipesPage = GetFavoriteRecipesPageUseCase(favoritesRepo),
 			getCookbooksPage = GetCookbooksPageUseCase(FakeCookbooksRepository()),
 			createCookbook = CreateCookbookUseCase(FakeCookbooksRepository()),
 			deleteCookbookUseCase = DeleteCookbookUseCase(FakeCookbooksRepository()),
 			getCookbookRecipesPage = GetCookbookRecipesPageUseCase(FakeCookbooksRepository()),
 			getCookbookCoverImageUrl = getCookbookCoverImageUrl,
 			importCookbookShare = unusedImportCookbookShareUseCase(),
+			observeFavoriteEvents = ObserveFavoriteEventsUseCase(favoritesRepo),
 			shareCookbook = unusedShareCookbookUseCase(),
 			sessionKey = "session",
 		)
@@ -102,6 +105,58 @@ class FavoritesViewModelTest {
 
 		kotlin.test.assertEquals("Favorites failed", viewModel.savedErrorMessage)
 		kotlin.test.assertEquals(emptyList(), viewModel.savedRecipes.toList())
+	}
+
+	@Test
+	fun `favorite event reloads saved recipes`() = runViewModelTest {
+		val recipe = RecipeSummary(
+			id = 42,
+			title = "Tomato Pasta",
+			cuisine = Cuisine.ITALIAN,
+			imageUrl = null,
+			totalTime = 25,
+			isFavorite = true,
+		)
+		val favoritesRepo = FakeFavoritesRepository(
+			getFavoriteRecipesPageResult = Ok(
+				SearchResultsPage(
+					items = listOf(recipe),
+					pageNumber = 1,
+					pageSize = 20,
+					totalMatches = 1,
+				),
+			),
+		)
+		val viewModel = FavoritesViewModel(
+			getFavoriteRecipesPage = GetFavoriteRecipesPageUseCase(favoritesRepo),
+			getCookbooksPage = GetCookbooksPageUseCase(FakeCookbooksRepository()),
+			createCookbook = CreateCookbookUseCase(FakeCookbooksRepository()),
+			deleteCookbookUseCase = DeleteCookbookUseCase(FakeCookbooksRepository()),
+			getCookbookRecipesPage = GetCookbookRecipesPageUseCase(FakeCookbooksRepository()),
+			getCookbookCoverImageUrl = getCookbookCoverImageUrl,
+			importCookbookShare = unusedImportCookbookShareUseCase(),
+			observeFavoriteEvents = ObserveFavoriteEventsUseCase(favoritesRepo),
+			shareCookbook = unusedShareCookbookUseCase(),
+			sessionKey = "session",
+		)
+
+		viewModel.loadFavorites()
+		advanceUntilIdle()
+		kotlin.test.assertEquals(listOf(recipe), viewModel.savedRecipes.toList())
+
+		favoritesRepo.getFavoriteRecipesPageResult = Ok(
+			SearchResultsPage(
+				items = emptyList(),
+				pageNumber = 1,
+				pageSize = 20,
+				totalMatches = 0,
+			),
+		)
+		favoritesRepo.emitFavoriteEvent(FavoriteEvent.Removed(recipeId = recipe.id))
+		advanceUntilIdle()
+
+		kotlin.test.assertEquals(emptyList(), viewModel.savedRecipes.toList())
+		kotlin.test.assertEquals(0, viewModel.totalSavedMatches)
 	}
 
 	@Test
@@ -122,16 +177,10 @@ class FavoritesViewModelTest {
 				),
 			),
 		)
-		val viewModel = FavoritesViewModel(
-			getFavoriteRecipesPage = GetFavoriteRecipesPageUseCase(FakeFavoritesRepository()),
-			getCookbooksPage = GetCookbooksPageUseCase(cookbooksRepository),
-			createCookbook = CreateCookbookUseCase(cookbooksRepository),
-			deleteCookbookUseCase = DeleteCookbookUseCase(cookbooksRepository),
-			getCookbookRecipesPage = GetCookbookRecipesPageUseCase(cookbooksRepository),
-			getCookbookCoverImageUrl = getCookbookCoverImageUrl,
-			importCookbookShare = unusedImportCookbookShareUseCase(),
-			shareCookbook = unusedShareCookbookUseCase(),
-			sessionKey = "session",
+		val favoritesRepo = FakeFavoritesRepository()
+		val viewModel = favoritesViewModel(
+			favoritesRepository = favoritesRepo,
+			cookbooksRepository = cookbooksRepository,
 		)
 		viewModel.loadFavorites()
 		advanceUntilIdle()
@@ -150,17 +199,7 @@ class FavoritesViewModelTest {
 	@Test
 	fun `delete cookbook rejects non-empty cookbook`() = runViewModelTest {
 		val cookbooksRepository = FakeCookbooksRepository()
-		val viewModel = FavoritesViewModel(
-			getFavoriteRecipesPage = GetFavoriteRecipesPageUseCase(FakeFavoritesRepository()),
-			getCookbooksPage = GetCookbooksPageUseCase(cookbooksRepository),
-			createCookbook = CreateCookbookUseCase(cookbooksRepository),
-			deleteCookbookUseCase = DeleteCookbookUseCase(cookbooksRepository),
-			getCookbookRecipesPage = GetCookbookRecipesPageUseCase(cookbooksRepository),
-			getCookbookCoverImageUrl = getCookbookCoverImageUrl,
-			importCookbookShare = unusedImportCookbookShareUseCase(),
-			shareCookbook = unusedShareCookbookUseCase(),
-			sessionKey = "session",
-		)
+		val viewModel = favoritesViewModel(cookbooksRepository = cookbooksRepository)
 		var deleted = true
 
 		viewModel.deleteCookbook(
@@ -182,17 +221,7 @@ class FavoritesViewModelTest {
 	@Test
 	fun `delete cookbook succeeds for empty cookbook`() = runViewModelTest {
 		val cookbooksRepository = FakeCookbooksRepository()
-		val viewModel = FavoritesViewModel(
-			getFavoriteRecipesPage = GetFavoriteRecipesPageUseCase(FakeFavoritesRepository()),
-			getCookbooksPage = GetCookbooksPageUseCase(cookbooksRepository),
-			createCookbook = CreateCookbookUseCase(cookbooksRepository),
-			deleteCookbookUseCase = DeleteCookbookUseCase(cookbooksRepository),
-			getCookbookRecipesPage = GetCookbookRecipesPageUseCase(cookbooksRepository),
-			getCookbookCoverImageUrl = getCookbookCoverImageUrl,
-			importCookbookShare = unusedImportCookbookShareUseCase(),
-			shareCookbook = unusedShareCookbookUseCase(),
-			sessionKey = "session",
-		)
+		val viewModel = favoritesViewModel(cookbooksRepository = cookbooksRepository)
 		var deleted = false
 
 		viewModel.deleteCookbook(
@@ -211,4 +240,21 @@ class FavoritesViewModelTest {
 		kotlin.test.assertEquals(null, viewModel.deleteCookbookError)
 		kotlin.test.assertEquals(1, cookbooksRepository.deleteCookbookCallCount)
 	}
+
+	private fun favoritesViewModel(
+		favoritesRepository: FakeFavoritesRepository = FakeFavoritesRepository(),
+		cookbooksRepository: FakeCookbooksRepository = FakeCookbooksRepository(),
+		sessionKey: String? = "session",
+	): FavoritesViewModel = FavoritesViewModel(
+		getFavoriteRecipesPage = GetFavoriteRecipesPageUseCase(favoritesRepository),
+		getCookbooksPage = GetCookbooksPageUseCase(cookbooksRepository),
+		createCookbook = CreateCookbookUseCase(cookbooksRepository),
+		deleteCookbookUseCase = DeleteCookbookUseCase(cookbooksRepository),
+		getCookbookRecipesPage = GetCookbookRecipesPageUseCase(cookbooksRepository),
+		getCookbookCoverImageUrl = getCookbookCoverImageUrl,
+		importCookbookShare = unusedImportCookbookShareUseCase(),
+		observeFavoriteEvents = ObserveFavoriteEventsUseCase(favoritesRepository),
+		shareCookbook = unusedShareCookbookUseCase(),
+		sessionKey = sessionKey,
+	)
 }

--- a/feature/main/src/commonMain/kotlin/app/purecipes/feature/main/ui/MainScreen.kt
+++ b/feature/main/src/commonMain/kotlin/app/purecipes/feature/main/ui/MainScreen.kt
@@ -11,9 +11,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.ui.NavDisplay
@@ -64,7 +61,6 @@ private fun MainScreenContent(
 			val backStack = viewModel.mainBackStack()
 			val rootDestination = backStack.firstOrNull()
 			val authenticationState = viewModel.authenticationState
-			var favoritesRefreshSignal by remember { mutableIntStateOf(0) }
 			val sessionKey = when (authenticationState) {
 				is AuthenticationState.SignedIn -> authenticationState.user.id
 				AuthenticationState.SignedOut -> null
@@ -122,7 +118,6 @@ private fun MainScreenContent(
 							navigator = viewModel.navigator,
 							canManageFavorites = canManageFavorites,
 							sessionKey = sessionKey,
-							onFavoriteChange = { favoritesRefreshSignal += 1 },
 							onStartCooking = viewModel::onStartCooking,
 							onOpenMeasurementPreferences = viewModel::onOpenSettings,
 						)
@@ -130,7 +125,6 @@ private fun MainScreenContent(
 							navigator = viewModel.navigator,
 						)
 						installFavoritesFlow(
-							refreshSignal = favoritesRefreshSignal,
 							sessionKey = sessionKey,
 							onRecipeSelect = viewModel::onRecipeSelected,
 						)

--- a/feature/recipedetails/ui/src/androidDeviceTest/kotlin/app/purecipes/feature/recipedetails/ui/RecipeDetailsScreenTest.kt
+++ b/feature/recipedetails/ui/src/androidDeviceTest/kotlin/app/purecipes/feature/recipedetails/ui/RecipeDetailsScreenTest.kt
@@ -48,7 +48,6 @@ class RecipeDetailsScreenTest {
 					canManageFavorites = true,
 					onOpenMeasurementPreferences = {},
 					onBack = {},
-					onFavoriteChange = {},
 					onStartCooking = {},
 					viewModel = recipeDetailsViewModelForTest(
 						recipeId = 7,

--- a/feature/recipedetails/ui/src/commonMain/kotlin/app/purecipes/feature/recipedetails/ui/RecipeDetailsScreen.kt
+++ b/feature/recipedetails/ui/src/commonMain/kotlin/app/purecipes/feature/recipedetails/ui/RecipeDetailsScreen.kt
@@ -14,11 +14,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,7 +33,6 @@ fun RecipeDetailsScreen(
 	canManageFavorites: Boolean,
 	onOpenMeasurementPreferences: () -> Unit,
 	onBack: () -> Unit,
-	onFavoriteChange: () -> Unit,
 	onStartCooking: (Int) -> Unit,
 	modifier: Modifier = Modifier,
 	sessionKey: String? = null,
@@ -43,16 +40,9 @@ fun RecipeDetailsScreen(
 		create(recipeId = recipeId, sessionKey = sessionKey)
 	},
 ) {
-	val currentOnFavoriteChange by rememberUpdatedState(onFavoriteChange)
 	var showCookbookSheet by remember { mutableStateOf(false) }
 	var showNutritionDialog by remember { mutableStateOf(false) }
 	var newCookbookName by remember { mutableStateOf("") }
-
-	LaunchedEffect(viewModel.favoriteChangeCount) {
-		if (viewModel.favoriteChangeCount > 0) {
-			currentOnFavoriteChange()
-		}
-	}
 
 	Box(modifier = modifier.fillMaxSize()) {
 		Scaffold(

--- a/feature/recipedetails/ui/src/commonMain/kotlin/app/purecipes/feature/recipedetails/ui/RecipeDetailsViewModel.kt
+++ b/feature/recipedetails/ui/src/commonMain/kotlin/app/purecipes/feature/recipedetails/ui/RecipeDetailsViewModel.kt
@@ -1,7 +1,6 @@
 package app.purecipes.feature.recipedetails.ui
 
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -77,9 +76,6 @@ class RecipeDetailsViewModel(
 	var isFavoriteUpdating by mutableStateOf(false)
 		private set
 
-	var favoriteChangeCount by mutableIntStateOf(0)
-		private set
-
 	val recipeCookbooks = mutableStateListOf<CookbookRef>()
 
 	val sheetCookbooks = mutableStateListOf<CookbookSummary>()
@@ -140,7 +136,6 @@ class RecipeDetailsViewModel(
 			if (outcome.getError() == null) {
 				baseRecipeDetails = baseRecipeDetails?.copy(isFavorite = !currentRecipe.isFavorite)
 				recipeDetails = currentRecipe.copy(isFavorite = !currentRecipe.isFavorite)
-				favoriteChangeCount += 1
 				trackEvent(
 					AnalyticsEvent.FavoriteChanged(
 						recipeId = currentRecipe.id,

--- a/feature/recipedetails/ui/src/commonMain/kotlin/app/purecipes/feature/recipedetails/ui/navigation/RecipeDetailsNavigation.kt
+++ b/feature/recipedetails/ui/src/commonMain/kotlin/app/purecipes/feature/recipedetails/ui/navigation/RecipeDetailsNavigation.kt
@@ -14,7 +14,6 @@ fun EntryProviderScope<NavKey>.installRecipeDetailsFlow(
 	navigator: Navigator,
 	canManageFavorites: Boolean,
 	sessionKey: String?,
-	onFavoriteChange: () -> Unit,
 	onStartCooking: (Int) -> Unit,
 	onOpenMeasurementPreferences: () -> Unit,
 ) {
@@ -24,7 +23,6 @@ fun EntryProviderScope<NavKey>.installRecipeDetailsFlow(
 			canManageFavorites = canManageFavorites,
 			onOpenMeasurementPreferences = onOpenMeasurementPreferences,
 			onBack = { navigator.back() },
-			onFavoriteChange = onFavoriteChange,
 			onStartCooking = onStartCooking,
 			sessionKey = sessionKey,
 			modifier = Modifier.fillMaxSize(),

--- a/feature/recipedetails/ui/src/commonTest/kotlin/app/purecipes/feature/recipedetails/ui/RecipeDetailsViewModelTest.kt
+++ b/feature/recipedetails/ui/src/commonTest/kotlin/app/purecipes/feature/recipedetails/ui/RecipeDetailsViewModelTest.kt
@@ -3,6 +3,7 @@ package app.purecipes.feature.recipedetails.ui
 import app.purecipes.base.kotlin.result.Failure
 import app.purecipes.base.kotlin.result.Outcome
 import app.purecipes.feature.analytics.domain.usecase.TrackEventUseCase
+import app.purecipes.feature.favorites.domain.model.FavoriteEvent
 import app.purecipes.feature.favorites.domain.repository.FavoritesRepository
 import app.purecipes.feature.favorites.domain.usecase.AddFavoriteRecipeUseCase
 import app.purecipes.feature.favorites.domain.usecase.AddRecipeToCookbookUseCase
@@ -31,6 +32,7 @@ import com.github.michaelbull.result.Ok
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlin.test.Test
 
@@ -128,7 +130,6 @@ class RecipeDetailsViewModelTest {
 		advanceUntilIdle()
 
 		true shouldBe viewModel.recipeDetails?.isFavorite
-		viewModel.favoriteChangeCount shouldBe 1
 		viewModel.favoriteErrorMessage shouldBe null
 	}
 
@@ -248,6 +249,8 @@ class RecipeDetailsViewModelTest {
 		)
 
 		override suspend fun removeFavorite(recipeId: Int): Outcome<Unit> = Ok(Unit)
+
+		override fun observeFavoriteEvents() = emptyFlow<FavoriteEvent>()
 	}
 
 }

--- a/shared/testfixtures/src/commonMain/kotlin/app/purecipes/shared/testfixtures/fake/FakeFavoritesRepository.kt
+++ b/shared/testfixtures/src/commonMain/kotlin/app/purecipes/shared/testfixtures/fake/FakeFavoritesRepository.kt
@@ -1,12 +1,17 @@
 package app.purecipes.shared.testfixtures.fake
 
 import app.purecipes.base.kotlin.result.Outcome
+import app.purecipes.feature.favorites.domain.model.FavoriteEvent
 import app.purecipes.feature.favorites.domain.repository.FavoritesRepository
 import app.purecipes.shared.domain.model.SearchResultsPage
 import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.getError
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 
 class FakeFavoritesRepository(
-	private val getFavoriteRecipesPageResult: Outcome<SearchResultsPage> = Ok(
+	var getFavoriteRecipesPageResult: Outcome<SearchResultsPage> = Ok(
 		SearchResultsPage(
 			items = emptyList(),
 			pageNumber = 1,
@@ -21,9 +26,15 @@ class FakeFavoritesRepository(
 	val addedRecipeIds = mutableListOf<Int>()
 	val removedRecipeIds = mutableListOf<Int>()
 
+	private val favoriteEvents = MutableSharedFlow<FavoriteEvent>(extraBufferCapacity = 1)
+
 	override suspend fun addFavorite(recipeId: Int): Outcome<Unit> {
 		addedRecipeIds += recipeId
-		return addFavoriteResult
+		return addFavoriteResult.also { outcome ->
+			if (outcome.getError() == null) {
+				favoriteEvents.tryEmit(FavoriteEvent.Added(recipeId))
+			}
+		}
 	}
 
 	override suspend fun getFavoriteRecipesPage(pageNumber: Int, pageSize: Int): Outcome<SearchResultsPage> =
@@ -31,6 +42,16 @@ class FakeFavoritesRepository(
 
 	override suspend fun removeFavorite(recipeId: Int): Outcome<Unit> {
 		removedRecipeIds += recipeId
-		return removeFavoriteResult
+		return removeFavoriteResult.also { outcome ->
+			if (outcome.getError() == null) {
+				favoriteEvents.tryEmit(FavoriteEvent.Removed(recipeId))
+			}
+		}
+	}
+
+	override fun observeFavoriteEvents(): Flow<FavoriteEvent> = favoriteEvents.asSharedFlow()
+
+	fun emitFavoriteEvent(event: FavoriteEvent) {
+		favoriteEvents.tryEmit(event)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `FavoriteEvent` and `observeFavoriteEvents()` on `FavoritesRepository`, emitted from `FavoritesAccessor` after successful add/remove.
- Add `ObserveFavoriteEventsUseCase`; `FavoritesViewModel` collects events and reloads favorites paging.
- Remove `favoritesRefreshSignal`, `refreshSignal`, and `onFavoriteChange` from main navigation and recipe details.

Closes #131.

## Test plan

- [x] `./gradlew detektAll`
- [x] `./gradlew :feature:favorites:domain:jvmTest :feature:favorites:data:jvmTest :feature:favorites:ui:jvmTest`
- [x] `./gradlew :feature:favorites:ui:connectedAndroidTest`
- [ ] `./gradlew connectedAndroidTest` (full app suite, optional)