### PR TITLE
130: Wire system back for nested screens on Android and Wasm

### DIFF
--- a/.agents/instructions/navigation-system-back.md
+++ b/.agents/instructions/navigation-system-back.md
@@ -1,0 +1,21 @@
+# System and platform back navigation
+
+## Android
+
+`MainScreen` registers `HandleSystemBack` for the full navigation stack. Hardware back calls `MainViewModel.onBack()`; when that returns `false` at the search tab root, `MainActivity` finishes the app.
+
+Nested destinations are popped via `Navigator.back()` on the shared `NavBackStack`. In-UI back controls (`BackNavigationButton`, toolbar buttons) call the same `navigator.back()` path through feature `onBack` callbacks.
+
+`NavDisplay` `onBack` is wired for navigation3 predictive back integration; system back is handled by `HandleSystemBack`, not duplicate `BackHandler` registrations elsewhere.
+
+## Wasm
+
+`HandleSystemBack` listens for browser `popstate` and invokes the same `onBack` callback as Android.
+
+`PlatformNavigationHistorySync` pushes a `history` entry when the back stack depth increases so the browser back button can pop in-app destinations first.
+
+Browser forward is not wired: there is no `Navigator.forward()`. In-app toolbar back does not call `history.back()`, so the browser history stack can diverge until the user uses browser back.
+
+## iOS
+
+`HandleSystemBack` is a no-op. Swipe-from-edge and navigation bar back are provided by the hosting `ComposeUIViewController` / UIKit integration with the Compose navigation stack.

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -7,6 +7,11 @@ plugins {
 kotlin {
 	android {
 		namespace = "app.purecipes.feature.main"
+		withDeviceTestBuilder {
+			sourceSetTreeName = "androidDeviceTest"
+		}.configure {
+			instrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+		}
 	}
 
 	sourceSets {
@@ -45,6 +50,12 @@ kotlin {
 		}
 		commonTest {
 			dependencies {
+				implementation(project(":shared:testfixtures"))
+			}
+		}
+		named("androidDeviceTest") {
+			dependencies {
+				implementation(libs.androidx.activityCompose)
 				implementation(project(":shared:testfixtures"))
 			}
 		}

--- a/feature/main/src/androidDeviceTest/kotlin/app/purecipes/feature/main/ui/MainScreenHardwareBackTest.kt
+++ b/feature/main/src/androidDeviceTest/kotlin/app/purecipes/feature/main/ui/MainScreenHardwareBackTest.kt
@@ -1,0 +1,122 @@
+package app.purecipes.feature.main.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.ui.NavDisplay
+import androidx.test.espresso.Espresso.pressBack
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.purecipes.feature.recipedetails.ui.RecipeDetailsScreen
+import app.purecipes.feature.recipedetails.ui.navigation.RecipeDetailsDestination
+import app.purecipes.feature.search.ui.RecipeSearchScreen
+import app.purecipes.feature.search.ui.navigation.SearchDestination
+import app.purecipes.shared.domain.model.Cuisine
+import app.purecipes.shared.domain.model.RecipeSummary
+import app.purecipes.shared.testfixtures.fake.FakeRecipeDetailsRepository
+import app.purecipes.shared.testfixtures.fake.FakeRecipeSearchRepository
+import app.purecipes.shared.testfixtures.fake.fakeRecipeDetails
+import app.purecipes.shared.ui.component.NavigationBackHandler
+import app.purecipes.shared.ui.theme.PurecipesTheme
+import com.github.michaelbull.result.Ok
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainScreenHardwareBackTest {
+
+	@get:Rule
+	val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+	@Test
+	fun hardwareBackFromRecipeDetailsReturnsToSearch() {
+		val mainViewModel = mainViewModelForDeviceTest()
+		val recipeId = HARDWARE_BACK_TEST_RECIPE_ID
+		val searchViewModel = recipeSearchViewModelForDeviceTest(
+			searchRepository = FakeRecipeSearchRepository(
+				result = Ok(
+					listOf(
+						RecipeSummary(
+							id = recipeId,
+							title = "Roasted Carrots",
+							cuisine = Cuisine.MEDITERRANEAN,
+							imageUrl = null,
+							totalTime = 35,
+						),
+					),
+				),
+			),
+		)
+		val recipeDetailsViewModel = recipeDetailsViewModelForDeviceTest(
+			recipeId = recipeId,
+			recipeDetailsRepository = FakeRecipeDetailsRepository(
+				fakeRecipeDetails(
+					id = recipeId,
+					title = "Roasted Carrots",
+					description = "Sweet and savory side dish.",
+				),
+			),
+		)
+
+		composeRule.setContent {
+			PurecipesTheme {
+				LaunchedEffect(mainViewModel) {
+					mainViewModel.start()
+				}
+				val backStack = mainViewModel.mainBackStack()
+				NavigationBackHandler(
+					enabled = true,
+					backStackDepth = backStack.size,
+					onBack = { mainViewModel.onBack() },
+				)
+				NavDisplay(
+					backStack = backStack,
+					modifier = Modifier.fillMaxSize(),
+					onBack = { mainViewModel.onBack() },
+					entryProvider = entryProvider {
+						entry<SearchDestination> {
+							RecipeSearchScreen(
+								modifier = Modifier.fillMaxSize(),
+								isSignedIn = true,
+								onRecipeSelect = mainViewModel::onRecipeSelected,
+								onRequestLogInForFilters = {},
+								viewModel = searchViewModel,
+							)
+						}
+						entry<RecipeDetailsDestination> { destination ->
+							RecipeDetailsScreen(
+								recipeId = destination.recipeId,
+								canManageFavorites = true,
+								onOpenMeasurementPreferences = {},
+								onBack = { mainViewModel.onBack() },
+								onStartCooking = {},
+								viewModel = recipeDetailsViewModel,
+							)
+						}
+					},
+				)
+			}
+		}
+
+		composeRule.runOnIdle {
+			mainViewModel.onRecipeSelected(recipeId)
+		}
+
+		composeRule.waitForIdle()
+		composeRule.onNodeWithText("Sweet and savory side dish.").assertIsDisplayed()
+		composeRule.onNodeWithText("Start cooking").assertIsDisplayed()
+
+		pressBack()
+
+		composeRule.waitForIdle()
+		composeRule.onNodeWithText("1 recipes found").assertIsDisplayed()
+		composeRule.onAllNodesWithText("Start cooking").assertCountEquals(0)
+	}
+}

--- a/feature/main/src/androidDeviceTest/kotlin/app/purecipes/feature/main/ui/MainScreenHardwareBackTestFixtures.kt
+++ b/feature/main/src/androidDeviceTest/kotlin/app/purecipes/feature/main/ui/MainScreenHardwareBackTestFixtures.kt
@@ -1,0 +1,109 @@
+package app.purecipes.feature.main.ui
+
+import app.purecipes.feature.analytics.domain.model.ConsentState
+import app.purecipes.feature.analytics.domain.usecase.RefreshConsentUseCase
+import app.purecipes.feature.analytics.domain.usecase.SetAnalyticsUserIdUseCase
+import app.purecipes.feature.analytics.domain.usecase.TrackEventUseCase
+import app.purecipes.feature.auth.domain.usecase.ObserveAuthenticationStateUseCase
+import app.purecipes.feature.favorites.domain.usecase.AddFavoriteRecipeUseCase
+import app.purecipes.feature.favorites.domain.usecase.AddRecipeToCookbookUseCase
+import app.purecipes.feature.favorites.domain.usecase.CreateCookbookUseCase
+import app.purecipes.feature.favorites.domain.usecase.GetCookbooksPageUseCase
+import app.purecipes.feature.favorites.domain.usecase.GetRecipeCookbooksUseCase
+import app.purecipes.feature.favorites.domain.usecase.RemoveFavoriteRecipeUseCase
+import app.purecipes.feature.measurement.domain.usecase.FilterRecipesForMeasurementPreferencesUseCase
+import app.purecipes.feature.measurement.domain.usecase.GetMeasurementPreferencesUseCase
+import app.purecipes.feature.measurement.domain.usecase.MarkMeasurementMismatchSeenUseCase
+import app.purecipes.feature.measurement.domain.usecase.ProcessRecipeDetailsForMeasurementPreferencesUseCase
+import app.purecipes.feature.recipedetails.domain.usecase.GetRecipeDetailsUseCase
+import app.purecipes.feature.recipedetails.ui.RecipeDetailsViewModel
+import app.purecipes.feature.search.domain.usecase.GetSearchFiltersUseCase
+import app.purecipes.feature.search.domain.usecase.GetUserPantryUseCase
+import app.purecipes.feature.search.domain.usecase.SaveSearchFiltersUseCase
+import app.purecipes.feature.search.domain.usecase.SearchRecipesUseCase
+import app.purecipes.feature.search.domain.usecase.UpdateUserPantryUseCase
+import app.purecipes.feature.search.ui.RecipeSearchViewModel
+import app.purecipes.feature.sharing.domain.model.PurecipesLink
+import app.purecipes.feature.sharing.domain.repository.IncomingLinkRepository
+import app.purecipes.feature.sharing.domain.repository.ShareRepository
+import app.purecipes.feature.sharing.domain.repository.WebLaunchLinkRepository
+import app.purecipes.feature.sharing.domain.usecase.ObserveIncomingLinksUseCase
+import app.purecipes.feature.sharing.domain.usecase.PublishWebLaunchLinkUseCase
+import app.purecipes.feature.sharing.domain.usecase.ShareRecipeUseCase
+import app.purecipes.shared.data.config.PurecipesBuildType
+import app.purecipes.shared.data.config.PurecipesConfig
+import app.purecipes.shared.testfixtures.fake.FakeAnalyticsRepository
+import app.purecipes.shared.testfixtures.fake.FakeAuthenticationRepository
+import app.purecipes.shared.testfixtures.fake.FakeConsentRepository
+import app.purecipes.shared.testfixtures.fake.FakeCookbooksRepository
+import app.purecipes.shared.testfixtures.fake.FakeFavoritesRepository
+import app.purecipes.shared.testfixtures.fake.FakeMeasurementPreferencesRepository
+import app.purecipes.shared.testfixtures.fake.FakeRecipeDetailsRepository
+import app.purecipes.shared.testfixtures.fake.FakeRecipeSearchFilterRepository
+import app.purecipes.shared.testfixtures.fake.FakeRecipeSearchRepository
+import app.purecipes.shared.testfixtures.fake.FakeUserPantryRepository
+import kotlinx.coroutines.flow.emptyFlow
+
+internal const val HARDWARE_BACK_TEST_RECIPE_ID = 7
+
+internal fun mainViewModelForDeviceTest(): MainViewModel = MainViewModel(
+	observeAuthenticationState = ObserveAuthenticationStateUseCase(FakeAuthenticationRepository()),
+	refreshConsent = RefreshConsentUseCase(FakeConsentRepository(ConsentState.NOT_REQUIRED)),
+	setAnalyticsUserId = SetAnalyticsUserIdUseCase(FakeAnalyticsRepository()),
+	observeIncomingLinks = ObserveIncomingLinksUseCase(emptyIncomingLinkRepositoryForDeviceTest()),
+	publishWebLaunchLink = PublishWebLaunchLinkUseCase(
+		object : WebLaunchLinkRepository {
+			override fun readLaunchUrl(): String? = null
+		},
+		emptyIncomingLinkRepositoryForDeviceTest(),
+	),
+	purecipesConfig = object : PurecipesConfig {
+		override fun buildType(): PurecipesBuildType = PurecipesBuildType.DEBUG
+	},
+	onDeliverPendingIncomingLink = {},
+)
+
+internal fun recipeSearchViewModelForDeviceTest(
+	searchRepository: FakeRecipeSearchRepository = FakeRecipeSearchRepository(),
+): RecipeSearchViewModel = RecipeSearchViewModel(
+	filterRecipesForMeasurementPreferences = FilterRecipesForMeasurementPreferencesUseCase(),
+	getMeasurementPreferences = GetMeasurementPreferencesUseCase(FakeMeasurementPreferencesRepository()),
+	searchRecipes = SearchRecipesUseCase(searchRepository),
+	trackEvent = TrackEventUseCase(FakeAnalyticsRepository()),
+	getSearchFilters = GetSearchFiltersUseCase(FakeRecipeSearchFilterRepository()),
+	saveSearchFilters = SaveSearchFiltersUseCase(FakeRecipeSearchFilterRepository()),
+	getUserPantry = GetUserPantryUseCase(FakeUserPantryRepository()),
+	updateUserPantry = UpdateUserPantryUseCase(FakeUserPantryRepository()),
+	initialShowFilterSheet = false,
+	sessionKey = null,
+)
+
+internal fun recipeDetailsViewModelForDeviceTest(
+	recipeId: Int,
+	recipeDetailsRepository: FakeRecipeDetailsRepository,
+): RecipeDetailsViewModel = RecipeDetailsViewModel(
+	addFavoriteRecipe = AddFavoriteRecipeUseCase(FakeFavoritesRepository()),
+	getRecipeDetails = GetRecipeDetailsUseCase(recipeDetailsRepository),
+	getMeasurementPreferences = GetMeasurementPreferencesUseCase(FakeMeasurementPreferencesRepository()),
+	markMeasurementMismatchSeen = MarkMeasurementMismatchSeenUseCase(FakeMeasurementPreferencesRepository()),
+	processRecipeDetailsForMeasurementPreferences = ProcessRecipeDetailsForMeasurementPreferencesUseCase(),
+	removeFavoriteRecipe = RemoveFavoriteRecipeUseCase(FakeFavoritesRepository()),
+	trackEvent = TrackEventUseCase(FakeAnalyticsRepository()),
+	getRecipeCookbooks = GetRecipeCookbooksUseCase(FakeCookbooksRepository()),
+	getCookbooksPage = GetCookbooksPageUseCase(FakeCookbooksRepository()),
+	createCookbook = CreateCookbookUseCase(FakeCookbooksRepository()),
+	addRecipeToCookbook = AddRecipeToCookbookUseCase(FakeCookbooksRepository()),
+	shareRecipe = ShareRecipeUseCase(
+		object : ShareRepository {
+			override fun shareText(text: String, title: String?) = Unit
+		},
+	),
+	recipeId = recipeId,
+	sessionKey = null,
+)
+
+private fun emptyIncomingLinkRepositoryForDeviceTest(): IncomingLinkRepository = object : IncomingLinkRepository {
+	override fun observeLinks() = emptyFlow<PurecipesLink>()
+
+	override fun deliver(url: String) = Unit
+}

--- a/feature/main/src/commonMain/kotlin/app/purecipes/feature/main/ui/MainScreen.kt
+++ b/feature/main/src/commonMain/kotlin/app/purecipes/feature/main/ui/MainScreen.kt
@@ -22,7 +22,7 @@ import app.purecipes.feature.newrecipe.ui.navigation.installCreateFlow
 import app.purecipes.feature.recipedetails.ui.navigation.installRecipeDetailsFlow
 import app.purecipes.feature.search.ui.navigation.installSearchFlow
 import app.purecipes.feature.settings.ui.navigation.installSettingsFlow
-import app.purecipes.shared.ui.component.HandleSystemBack
+import app.purecipes.shared.ui.component.NavigationBackHandler
 import app.purecipes.shared.ui.navigation.PostLoginAction
 import app.purecipes.shared.ui.theme.PurecipesTheme
 import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
@@ -67,8 +67,9 @@ private fun MainScreenContent(
 				AuthenticationState.SignedOut -> null
 			}
 			val canManageFavorites = authenticationState is AuthenticationState.SignedIn
-			HandleSystemBack(
+			NavigationBackHandler(
 				enabled = true,
+				backStackDepth = backStack.size,
 				onBack = {
 					if (!viewModel.onBack()) {
 						onExitRequest()

--- a/feature/main/src/commonTest/kotlin/app/purecipes/feature/main/ui/MainViewModelTest.kt
+++ b/feature/main/src/commonTest/kotlin/app/purecipes/feature/main/ui/MainViewModelTest.kt
@@ -101,6 +101,12 @@ class MainViewModelTest {
 	}
 
 	@Test
+	fun `onBack at search root returns false`() {
+		val viewModel = mainViewModelForTest()
+		viewModel.onBack() shouldBe false
+	}
+
+	@Test
 	fun `back removes only the top destination`() {
 		val viewModel = mainViewModelForTest()
 		viewModel.onRecipeSelected(42)

--- a/shared/ui/src/androidMain/kotlin/app/purecipes/shared/ui/component/PlatformNavigationHistorySync.kt
+++ b/shared/ui/src/androidMain/kotlin/app/purecipes/shared/ui/component/PlatformNavigationHistorySync.kt
@@ -1,0 +1,6 @@
+package app.purecipes.shared.ui.component
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual fun PlatformNavigationHistorySync(backStackDepth: Int) = Unit

--- a/shared/ui/src/commonMain/kotlin/app/purecipes/shared/ui/component/NavigationBackHandler.kt
+++ b/shared/ui/src/commonMain/kotlin/app/purecipes/shared/ui/component/NavigationBackHandler.kt
@@ -1,0 +1,13 @@
+package app.purecipes.shared.ui.component
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun NavigationBackHandler(
+	enabled: Boolean,
+	backStackDepth: Int,
+	onBack: () -> Unit,
+) {
+	PlatformNavigationHistorySync(backStackDepth)
+	HandleSystemBack(enabled = enabled, onBack = onBack)
+}

--- a/shared/ui/src/commonMain/kotlin/app/purecipes/shared/ui/component/PlatformNavigationHistorySync.kt
+++ b/shared/ui/src/commonMain/kotlin/app/purecipes/shared/ui/component/PlatformNavigationHistorySync.kt
@@ -1,0 +1,6 @@
+package app.purecipes.shared.ui.component
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal expect fun PlatformNavigationHistorySync(backStackDepth: Int)

--- a/shared/ui/src/iosMain/kotlin/app/purecipes/shared/ui/component/PlatformNavigationHistorySync.kt
+++ b/shared/ui/src/iosMain/kotlin/app/purecipes/shared/ui/component/PlatformNavigationHistorySync.kt
@@ -1,0 +1,6 @@
+package app.purecipes.shared.ui.component
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual fun PlatformNavigationHistorySync(backStackDepth: Int) = Unit

--- a/shared/ui/src/jvmMain/kotlin/app/purecipes/shared/ui/component/PlatformNavigationHistorySync.kt
+++ b/shared/ui/src/jvmMain/kotlin/app/purecipes/shared/ui/component/PlatformNavigationHistorySync.kt
@@ -1,0 +1,6 @@
+package app.purecipes.shared.ui.component
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual fun PlatformNavigationHistorySync(backStackDepth: Int) = Unit

--- a/shared/ui/src/wasmJsMain/kotlin/app/purecipes/shared/ui/component/HandleSystemBack.kt
+++ b/shared/ui/src/wasmJsMain/kotlin/app/purecipes/shared/ui/component/HandleSystemBack.kt
@@ -1,6 +1,24 @@
 package app.purecipes.shared.ui.component
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import kotlinx.browser.window
+import org.w3c.dom.events.Event
+import kotlin.js.ExperimentalWasmJsInterop
 
+@OptIn(ExperimentalWasmJsInterop::class)
 @Composable
-actual fun HandleSystemBack(enabled: Boolean, onBack: () -> Unit) = Unit
+actual fun HandleSystemBack(enabled: Boolean, onBack: () -> Unit) {
+	DisposableEffect(enabled, onBack) {
+		if (!enabled) {
+			return@DisposableEffect onDispose {}
+		}
+		val listener: (Event) -> Unit = {
+			onBack()
+		}
+		window.addEventListener("popstate", listener)
+		onDispose {
+			window.removeEventListener("popstate", listener)
+		}
+	}
+}

--- a/shared/ui/src/wasmJsMain/kotlin/app/purecipes/shared/ui/component/PlatformNavigationHistorySync.kt
+++ b/shared/ui/src/wasmJsMain/kotlin/app/purecipes/shared/ui/component/PlatformNavigationHistorySync.kt
@@ -1,0 +1,22 @@
+package app.purecipes.shared.ui.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.browser.window
+import kotlin.js.ExperimentalWasmJsInterop
+
+@OptIn(ExperimentalWasmJsInterop::class)
+@Composable
+internal actual fun PlatformNavigationHistorySync(backStackDepth: Int) {
+	var previousDepth by remember { mutableIntStateOf(backStackDepth) }
+	LaunchedEffect(backStackDepth) {
+		if (backStackDepth > previousDepth) {
+			window.history.pushState(null, "", window.location.href)
+		}
+		previousDepth = backStackDepth
+	}
+}


### PR DESCRIPTION
## Summary

- Route Android hardware back and Wasm browser `popstate` through `NavigationBackHandler`, delegating to `MainViewModel.onBack()` and exiting only at the search tab root.
- Push browser history entries when the back stack depth grows on Wasm; document Android, Wasm, and iOS back behavior in `.agents/instructions/navigation-system-back.md`.
- Add `MainScreenHardwareBackTest` (device) and a `MainViewModel` unit test for search-root back behavior.

Closes #130

## Test plan

- [x] `./gradlew detektAll`
- [x] `./gradlew :feature:main:jvmTest`
- [x] `./gradlew :feature:main:compileAndroidDeviceTest`
- [ ] `./gradlew :feature:main:connectedAndroidDeviceTest` (requires connected device/emulator)