### PR TITLE
Release 0.3.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Purecipes are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.1] - 2026-06-08
+
+### Fixed
+
+- Android release builds now include all required app configuration, so tester updates can be distributed successfully.
+
 ## [0.3.0] - 2026-06-08
 
 ### Added

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 
 #common configuration
 
-versionCode = "5"
-versionName = "0.3.0"
+versionCode = "6"
+versionName = "0.3.1"
 minSdkVersion = "24"
 compileSdkVersion = "37"
 targetSdkVersion = "37"


### PR DESCRIPTION
## Release 0.3.1

Bug-fix release following **v0.3.0**.

### Changes since v0.3.0

- `Fix missing property for release version` — adds the missing `PURECIPES_DEBUG_BACKEND_HOST` BuildConfig field so release builds compile and can be distributed.

### Version bump

| Field | Previous | New |
|-------|----------|-----|
| `versionName` | `0.3.0` | `0.3.1` |
| `versionCode` | `5` | `6` |

### Review checklist

- [ ] Changelog wording is accurate and tester-friendly
- [ ] `versionName` is `0.3.1`
- [ ] `versionCode` incremented to `6`
- [ ] Merge this PR before tagging `v0.3.1` on `main`

### After merge

Tag `v0.3.1` on `main` to trigger the Android distribute workflow.